### PR TITLE
Choosing the device(s) on which the tests are running

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -4,34 +4,42 @@ on:
   workflow_call:
     inputs:
       app_repository:
+        description: 'The GIT repository to build (defaults to `github.repository`)'
         required: false
         default: ${{ github.repository }}
         type: string
       app_branch_name:
+        description: 'The GIT branch to build (defaults to `github.ref`)'
         required: false
         default: ${{ github.ref }}
         type: string
       relative_app_directory:
+        description: "The directory where the application is built (defaults to current directory)"
         required: false
         default: .
         type: string
       flags:
+        description: "Additional compilation flags (default to none)"
         required: false
         default: ''
         type: string
       upload_app_binaries_artifact:
+        description: "The name of the artifact containing the built application binary file(s) to be tested"
         required: false
         default: ''
         type: string
       upload_as_lib_artifact:
+        description: "If non-empty, prefixes the built application binary file(s) with this string (default to none)"
         required: false
         default: ''
         type: string
-      skip_stax:
+      run_for_devices:
+        description: 'The list of device(s) on which the test will run (defaults to ["nanos", "nanox", "nanosp", "stax"])'
         required: false
-        default: false
-        type: boolean
+        default: '["nanos", "nanox", "nanosp", "stax"]'
+        type: string
       builder:
+        description: "The docker image to build the application in (defaults to ledger-app-builder-lite)"
         required: false
         default: 'ledger-app-builder-lite'
         type: string
@@ -42,22 +50,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - SDK: "$NANOS_SDK"
-            name: nanos
-          - SDK: "$NANOX_SDK"
-            name: nanox
-          - SDK: "$NANOSP_SDK"
-            name: nanos2
-          - SDK: "$STAX_SDK"
-            name: stax
+        device: ${{ fromJSON(inputs.run_for_devices) }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/ledgerhq/ledger-app-builder/${{ inputs.builder }}:latest
 
     steps:
       - name: Clone
-        if: ${{ !( inputs.skip_stax && matrix.target.name == 'stax' ) }}
         uses: actions/checkout@v3
         with:
           repository: ${{ inputs.app_repository }}
@@ -65,24 +64,25 @@ jobs:
           submodules: recursive
 
       - name: Build application
-        if: ${{ !( inputs.skip_stax && matrix.target.name == 'stax' ) }}
         run: |
-          make -C ${{ inputs.relative_app_directory }} -j ${{ inputs.flags }} BOLOS_SDK=${{ matrix.target.SDK }}
+          eval "BOLOS_SDK=\$$(echo ${{ matrix.device }} | tr [:lower:] [:upper:])_SDK" && \
+          echo "BOLOS_SDK value will be: ${BOLOS_SDK}" && \
+          make -C ${{ inputs.relative_app_directory }} -j ${{ inputs.flags }} BOLOS_SDK=${BOLOS_SDK}
 
       - name: Remove build artifacts before upload
-        if: ${{ !( inputs.skip_stax && matrix.target.name == 'stax' ) }}
         run: |
-          find ${{ inputs.relative_app_directory }}/build/${{ matrix.target.name }}/ -mindepth 1 -type d ! -name 'bin' -exec rm -r {} +
+          find ${{ inputs.relative_app_directory }}/build/ -mindepth 2 -type d ! -name 'bin' -exec rm -r {} +
 
       - name: Prepare to upload as lib
-        if: ${{ inputs.upload_as_lib_artifact != '' && !( inputs.skip_stax && matrix.target.name == 'stax' ) }}
+        if: ${{ inputs.upload_as_lib_artifact != '' }}
         run: |
-          find ${{ inputs.relative_app_directory }}/build/${{ matrix.target.name }}/ -type f -name 'app.elf' -exec mv {} ${{ inputs.upload_as_lib_artifact }}_${{ matrix.target.name }}.elf \;
-          rm -r ${{ inputs.relative_app_directory }}/build/*
-          mv ${{ inputs.upload_as_lib_artifact }}_${{ matrix.target.name }}.elf ${{ inputs.relative_app_directory }}/build/
+          DEVICE_NAME="$(echo ${{ matrix.device }} | tr nanosp nanos2)" && \
+          find ${{ inputs.relative_app_directory }}/build/${DEVICE_NAME}/ -type f -name 'app.elf' -exec mv {} ${{ inputs.upload_as_lib_artifact }}_${DEVICE_NAME}.elf \; && \
+          rm -r ${{ inputs.relative_app_directory }}/build/* && \
+          mv ${{ inputs.upload_as_lib_artifact }}_${DEVICE_NAME}.elf ${{ inputs.relative_app_directory }}/build/
 
       - name: Upload app binary
-        if: ${{ inputs.upload_app_binaries_artifact != '' && !( inputs.skip_stax && matrix.target.name == 'stax' ) }}
+        if: ${{ inputs.upload_app_binaries_artifact != '' }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.upload_app_binaries_artifact }}

--- a/.github/workflows/reusable_ragger_tests.yml
+++ b/.github/workflows/reusable_ragger_tests.yml
@@ -4,28 +4,40 @@ on:
   workflow_call:
     inputs:
       app_repository:
+        description: 'The GIT repository to test (defaults to `github.repository`)'
         required: false
         default: ${{ github.repository }}
         type: string
       app_branch_name:
+        description: 'The GIT branch to test (defaults to `github.ref`)'
         required: false
         default: ${{ github.ref }}
         type: string
       relative_app_directory:
+        description: "The directory where the application is built (defaults to current directory)"
         required: false
         default: .
         type: string
       test_dir:
+        description: "The directory where the Python tests are stored (a `conftest.py` file is expected there). Required"
         required: true
         type: string
       download_app_binaries_artifact:
+        description: "The name of the artifact containing the application binary file(s) to be tested. Required"
         required: true
         type: string
       lib_binaries_artifact:
+        description: "The name of the artifact containing the library binary file(s), if needed by the application to be tested (defaults to empty string)"
         required: false
         default: ''
         type: string
+      run_for_devices:
+        description: 'The list of device(s) on which the test will run (defaults to ["nanos", "nanox", "nanosp", "stax"])'
+        required: false
+        default: '["nanos", "nanox", "nanosp", "stax"]'
+        type: string
       skip_stax:
+        description: "If the tests are not to be run on Stax device (defaults to false)"
         required: false
         default: false
         type: boolean
@@ -36,11 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - device: nanos
-          - device: nanox
-          - device: nanosp
-          - device: stax
+        device: ${{ fromJSON(inputs.run_for_devices) }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/reusable_ragger_tests.yml
+++ b/.github/workflows/reusable_ragger_tests.yml
@@ -14,7 +14,7 @@ on:
         default: ${{ github.ref }}
         type: string
       relative_app_directory:
-        description: "The directory where the application is built (defaults to current directory)"
+        description: "The relative path in the repository where the application is built from (defaults to '.')"
         required: false
         default: .
         type: string

--- a/.github/workflows/reusable_ragger_tests.yml
+++ b/.github/workflows/reusable_ragger_tests.yml
@@ -36,11 +36,6 @@ on:
         required: false
         default: '["nanos", "nanox", "nanosp", "stax"]'
         type: string
-      skip_stax:
-        description: "If the tests are not to be run on Stax device (defaults to false)"
-        required: false
-        default: false
-        type: boolean
 
 jobs:
   ragger_tests:
@@ -53,7 +48,6 @@ jobs:
 
     steps:
       - name: Clone
-        if: ${{ !( inputs.skip_stax && matrix.device == 'stax' ) }}
         uses: actions/checkout@v3
         with:
           repository: ${{ inputs.app_repository }}
@@ -61,27 +55,24 @@ jobs:
           submodules: recursive
 
       - name: Download app binaries
-        if: ${{ !( inputs.skip_stax && matrix.device == 'stax' ) }}
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.download_app_binaries_artifact }}
           path: ${{ inputs.relative_app_directory }}/build/
 
       - name: Download additional lib binaries if required
-        if: ${{ inputs.lib_binaries_artifact != '' && !( inputs.skip_stax && matrix.device == 'stax' ) }}
+        if: ${{ inputs.lib_binaries_artifact != '' }}
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.lib_binaries_artifact }}
           path: ${{ inputs.test_dir }}/lib_binaries/
 
       - name: Install tests dependencies
-        if: ${{ !( inputs.skip_stax && matrix.device == 'stax' ) }}
         run: |
           sudo apt-get update && sudo apt-get install -y qemu-user-static tesseract-ocr libtesseract-dev
           pip install --extra-index-url https://test.pypi.org/simple/ -r ${{ inputs.test_dir }}/requirements.txt
 
       - name: Run test
-        if: ${{ !( inputs.skip_stax && matrix.device == 'stax' ) }}
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
         run: pytest ${{ inputs.test_dir }}/ --tb=short -v --device ${{ matrix.device }}


### PR DESCRIPTION
For now, only the `skip_stax` input allows to control on which devices the tests run.

This is quite limited, and I have a usecase where **only** Stax is tested, and I would like the test to run only on it, while using these reusable workflows.

So I propose this new input which should bring a bit more flexibility, by allowing the user to specify a list of device on which the tests should run. This directly mutes the `matrix` fields, so there is no "ghost" jobs created then immediately skipped.
Example [with this action](https://github.com/LedgerHQ/app-recovery-check/actions/runs/4372593910).

The downside is that GitHub does not allow lists as input types (there is only `string`, `bool`, `env` and `choice`, very limiting types but it is how it is), so I'm using a string which will be interpreted as a list thanks to the `fromJSON` function. So this works but users have to specify `'["nanos", "nanox"]'` with extra quites, so that's a bit sad.

Now, this input is a bit redundant with the existing `skip_stax` input. I did not removed it because I don't know how it would impact the existing workflows.