### PR TITLE
[add] Optional authentication token for GIT operations

### DIFF
--- a/.github/workflows/_get_workflow_version.yaml
+++ b/.github/workflows/_get_workflow_version.yaml
@@ -33,6 +33,10 @@ on:
         description: Name of reusable workflow file (e.g. "build_charms_with_cache.yaml")
         required: true
         type: string
+    secrets:
+      git_token:
+        description: 'A token used as authentication for GIT operations. Useful when including this workflow in a private repository.'
+        required: false
     outputs:
       version:
         description: Version of reusable workflow
@@ -95,7 +99,7 @@ jobs:
                   commands = [
                       "git init",
                       "git sparse-checkout set --sparse-index .github/workflows/",
-                      f"git remote add --fetch origin https://github.com/{repository_name}.git",
+                      f"git remote add --fetch origin https://${{ secrets.git_token }}@github.com/{repository_name}.git",
                       f"git fetch origin {ref}",
                       "git checkout FETCH_HEAD",
                   ]

--- a/.github/workflows/reusable_guidelines_enforcer.yml
+++ b/.github/workflows/reusable_guidelines_enforcer.yml
@@ -13,6 +13,10 @@ on:
         required: false
         default: '.'
         type: string
+    secrets:
+      git_token:
+        description: 'A token used as authentication for GIT operations. Useful when including this workflow in a private repository.'
+        required: false
 
 jobs:
   # We can't simply know the current ledger-app-workflow ref from inside the reusable workflow
@@ -24,6 +28,8 @@ jobs:
     with:
       repository-name: LedgerHQ/ledger-app-workflows
       file-name: reusable_guidelines_enforcer.yml
+    secrets:
+      git_token: ${{ secrets.git_token }}
 
   call_get_app_manifest:
     name: Dump app information


### PR DESCRIPTION
This change will allow private repositories to use the `guidelines_enforcer` workflow, by giving a PAT delegating the access of the private repository to this workflow.

It seems it does not temper with workflows which does **not** provide any token (example [here](https://github.com/LedgerHQ/app-passwords/actions/runs/5375262899)) - i.e all the existing app workflows.