### PR TITLE
Remove cargo ledger setup step from Rust workflows.

### DIFF
--- a/.github/workflows/_check_clang_static_analyzer.yml
+++ b/.github/workflows/_check_clang_static_analyzer.yml
@@ -39,7 +39,6 @@ jobs:
         run: |
           cd ${{ inputs.relative_app_directory }} && \
           DEVICE_NAME="$(echo ${{ matrix.device }} | sed 's/nanosp/nanosplus/')" && \
-          cargo ledger setup && \
           cargo clippy --target ${DEVICE_NAME} -- -Dwarnings
 
       - name: Build with Clang Static Analyzer

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -77,7 +77,6 @@ jobs:
           then
               DEVICE_NAME="$(echo ${{ matrix.device }} | sed 's/nanosp/nanosplus/')" && \
               cd ${{ inputs.relative_app_directory }} && \
-              cargo ledger setup && \
               cargo ledger build ${DEVICE_NAME} -- -Zunstable-options --out-dir=./build/${{ matrix.device }}/bin/
           else
               eval "BOLOS_SDK=\$$(echo ${{ matrix.device }} | tr [:lower:] [:upper:])_SDK" && \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Re-usable workflows for Ledger embedded applications
+# Reusable workflows for Ledger embedded applications
 
 This project contains several reusable Github workflows meant to be included in Ledger embedded applications repositories.
 


### PR DESCRIPTION
Remove `cargo ledger setup` step from Rust workflows. It has been integrated in `app-builder` since `3.6.0` image version.