### PR TITLE
This PR will make the `ledger_app.toml` manifest mandatory, and will drop the support of legacy Rust manifest

### DIFF
--- a/.github/workflows/_get_app_metadata.yml
+++ b/.github/workflows/_get_app_metadata.yml
@@ -82,58 +82,51 @@ jobs:
         id: fetch_metadata
         run: |
           pytest_directory='${{ inputs.pytest_directory }}';
-          if [[ -f "$APP_MANIFEST" ]];
+          if [[ ! -f "$APP_MANIFEST" ]];
           then
-              # 'ledger_app.toml' exists
-              if grep -q 'rust-app' "$APP_MANIFEST";
-              then
-                  # legacy manifest -> Rust application
-                  echo "Legacy manifest detected. Please update your manifest to the newest version";
-                  # checking the manifest with the repo
-                  ledger-manifest --legacy --check . "$APP_MANIFEST";
-                  echo "build_directory=$(ledger-manifest --legacy --output-build-directory "$APP_MANIFEST")" >> "$GITHUB_OUTPUT";
-                  compatible_devices='${{ inputs.compatible_devices }}';
-                  echo "is_rust=true" >> "$GITHUB_OUTPUT";
-              else
-                  # classic manifest -> can be either C or Rust
-                  echo "Manifest detected.";
-                  # checking the manifest with the repo
-                  ledger-manifest --check . "$APP_MANIFEST";
-                  echo "build_directory=$(ledger-manifest --output-build-directory "$APP_MANIFEST")" >> "$GITHUB_OUTPUT";
-                  compatible_devices="$(ledger-manifest --output-devices "$APP_MANIFEST")";
-
-                  set +e  # when [tests.pytest_directory] is not set, ledger-manifest fails
-                  if temp="$(ledger-manifest --output-pytest-directory "$APP_MANIFEST")";
-                  then
-                      pytest_directory="${temp}";
-                  fi
-                  set -e
-
-                  if [[ "$(ledger-manifest --output-sdk "$APP_MANIFEST")" == "rust" ]];
-                  then
-                      echo "is_rust=true" >> "$GITHUB_OUTPUT";
-                  else
-                      echo "is_rust=false" >> "$GITHUB_OUTPUT";
-                  fi
-              fi
-          else
-              # No 'ledger_app.toml' -> C application
-              echo "No manifest detected.";
-              echo "build_directory=${{ inputs.relative_app_directory }}" >> "$GITHUB_OUTPUT";
-              compatible_devices='${{ inputs.compatible_devices }}';
-              echo "is_rust=false" >> "$GITHUB_OUTPUT";
+              >&2 echo "/!\ No $APP_MANIFEST manifest detected!";
+              >&2 echo "This file is mandatory, please add it on your repository";
+              >&2 echo "Documentation here: https://github.com/LedgerHQ/ledgered/blob/master/doc/utils/manifest.md";
+              exit 1;
           fi
 
-          if [[ "${compatible_devices}" == 'None' ]];
+          # 'ledger_app.toml' exists
+          if grep -q 'rust-app' "$APP_MANIFEST";
           then
-              # no inputs and no classic manifest
-              compatible_devices='["nanos", "nanosp", "nanox", "stax"]';
+              # legacy manifest -> Rust application
+              echo "Legacy manifest detected. Please update your manifest to the newest version";
+              # checking the manifest with the repo
+              ledger-manifest --legacy --check . "$APP_MANIFEST";
+              echo "build_directory=$(ledger-manifest --legacy --output-build-directory "$APP_MANIFEST")" >> "$GITHUB_OUTPUT";
+              compatible_devices='${{ inputs.compatible_devices }}';
+              echo "is_rust=true" >> "$GITHUB_OUTPUT";
           else
-              if [[ '${{ inputs.compatible_devices }}' != 'None' ]];
+              # classic manifest -> can be either C or Rust
+              echo "Manifest detected.";
+              # checking the manifest with the repo
+              ledger-manifest --check . "$APP_MANIFEST";
+              echo "build_directory=$(ledger-manifest --output-build-directory "$APP_MANIFEST")" >> "$GITHUB_OUTPUT";
+              compatible_devices="$(ledger-manifest --output-devices "$APP_MANIFEST")";
+
+              set +e  # when [tests.pytest_directory] is not set, ledger-manifest fails
+              if temp="$(ledger-manifest --output-pytest-directory "$APP_MANIFEST")";
               then
-                  # in case classic manifest with devices, the input takes precedence on it
-                  compatible_devices='${{ inputs.compatible_devices }}';
+                  pytest_directory="${temp}";
               fi
+              set -e
+
+              if [[ "$(ledger-manifest --output-sdk "$APP_MANIFEST")" == "rust" ]];
+              then
+                  echo "is_rust=true" >> "$GITHUB_OUTPUT";
+              else
+                  echo "is_rust=false" >> "$GITHUB_OUTPUT";
+              fi
+          fi
+
+          if [[ '${{ inputs.compatible_devices }}' != 'None' ]];
+          then
+              # in case classic manifest with devices, the input takes precedence on it
+              compatible_devices='${{ inputs.compatible_devices }}';
           fi
 
           echo "compatible_devices=${compatible_devices}" | sed 's/+/p/' >> "$GITHUB_OUTPUT";

--- a/.github/workflows/_get_app_metadata.yml
+++ b/.github/workflows/_get_app_metadata.yml
@@ -13,15 +13,6 @@ on:
         required: false
         default: ${{ github.ref }}
         type: string
-      relative_app_directory:
-        description: |
-          The relative path in the repository where the application is built from (defaults to ".").
-
-          If the application is configured with a 'ledger_app.toml' manifest at its root, this
-          parameter is ignored.
-        required: false
-        default: .
-        type: string
       compatible_devices:
         description: |
           The list of device(s) the CI will run on.

--- a/.github/workflows/_get_app_metadata.yml
+++ b/.github/workflows/_get_app_metadata.yml
@@ -91,46 +91,38 @@ jobs:
           fi
 
           # 'ledger_app.toml' exists
-          if grep -q 'rust-app' "$APP_MANIFEST";
-          then
-              # legacy manifest -> Rust application
-              echo "Legacy manifest detected. Please update your manifest to the newest version";
-              # checking the manifest with the repo
-              ledger-manifest --legacy --check . "$APP_MANIFEST";
-              echo "build_directory=$(ledger-manifest --legacy --output-build-directory "$APP_MANIFEST")" >> "$GITHUB_OUTPUT";
-              compatible_devices='${{ inputs.compatible_devices }}';
-              echo "is_rust=true" >> "$GITHUB_OUTPUT";
-          else
-              # classic manifest -> can be either C or Rust
-              echo "Manifest detected.";
-              # checking the manifest with the repo
-              ledger-manifest --check . "$APP_MANIFEST";
-              echo "build_directory=$(ledger-manifest --output-build-directory "$APP_MANIFEST")" >> "$GITHUB_OUTPUT";
-              compatible_devices="$(ledger-manifest --output-devices "$APP_MANIFEST")";
+          echo "Manifest detected.";
+          # checking the manifest with the repo
+          ledger-manifest --check . "$APP_MANIFEST";
 
-              set +e  # when [tests.pytest_directory] is not set, ledger-manifest fails
-              if temp="$(ledger-manifest --output-pytest-directory "$APP_MANIFEST")";
-              then
-                  pytest_directory="${temp}";
-              fi
-              set -e
+          # build directory
+          echo "build_directory=$(ledger-manifest --output-build-directory "$APP_MANIFEST")" >> "$GITHUB_OUTPUT";
 
-              if [[ "$(ledger-manifest --output-sdk "$APP_MANIFEST")" == "rust" ]];
-              then
-                  echo "is_rust=true" >> "$GITHUB_OUTPUT";
-              else
-                  echo "is_rust=false" >> "$GITHUB_OUTPUT";
-              fi
-          fi
-
+          # device list
+          compatible_devices="$(ledger-manifest --output-devices "$APP_MANIFEST")";
           if [[ '${{ inputs.compatible_devices }}' != 'None' ]];
           then
               # in case classic manifest with devices, the input takes precedence on it
               compatible_devices='${{ inputs.compatible_devices }}';
           fi
-
           echo "compatible_devices=${compatible_devices}" | sed 's/+/p/' >> "$GITHUB_OUTPUT";
+
+          # pytest_directory (if any)
+          set +e  # when [tests.pytest_directory] is not set, ledger-manifest fails. We don't want that
+          if temp="$(ledger-manifest --output-pytest-directory "$APP_MANIFEST")";
+          then
+              pytest_directory="${temp}";
+          fi
+          set -e
           echo "pytest_directory=${pytest_directory}" >> "$GITHUB_OUTPUT";
+
+          # SDK language
+          if [[ "$(ledger-manifest --output-sdk "$APP_MANIFEST")" == "rust" ]];
+          then
+              echo "is_rust=true" >> "$GITHUB_OUTPUT";
+          else
+              echo "is_rust=false" >> "$GITHUB_OUTPUT";
+          fi
 
           echo "Inferred metadata:"
           cat "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -13,15 +13,6 @@ on:
         required: false
         default: ${{ github.ref }}
         type: string
-      relative_app_directory:
-        description: |
-          The relative path in the repository where the application is built from (defaults to ".")
-
-          If the application is configured with a 'ledger_app.toml' file at its root, this parameter
-          is ignored.
-        required: false
-        default: '.'
-        type: string
       flags:
         description: "Additional compilation flags (default to none)"
         required: false
@@ -63,7 +54,6 @@ jobs:
     with:
       app_repository: ${{ inputs.app_repository }}
       app_branch_name: ${{ inputs.app_branch_name }}
-      relative_app_directory: ${{ inputs.relative_app_directory }}
       compatible_devices: ${{ inputs.run_for_devices }}
 
   build:

--- a/.github/workflows/reusable_guidelines_enforcer.yml
+++ b/.github/workflows/reusable_guidelines_enforcer.yml
@@ -13,15 +13,6 @@ on:
         required: false
         default: 'None'
         type: string
-      relative_app_directory:
-        description: |
-          The relative path in the repository where the application is built from (defaults to ".")
-
-          If the application is configured with a 'ledger_app.toml' file at its root, this parameter
-          is ignored.
-        required: false
-        default: '.'
-        type: string
     secrets:
       git_token:
         description: 'A token used as authentication for GIT operations. Useful when including this workflow in a private repository.'
@@ -47,7 +38,6 @@ jobs:
     name: Retrieve application metadata
     uses: ./.github/workflows/_get_app_metadata.yml
     with:
-      relative_app_directory: ${{ inputs.relative_app_directory }}
       compatible_devices: ${{ inputs.run_for_devices }}
 
   call_get_app_manifest:

--- a/.github/workflows/reusable_ragger_tests.yml
+++ b/.github/workflows/reusable_ragger_tests.yml
@@ -14,11 +14,6 @@ on:
         required: false
         default: ${{ github.ref }}
         type: string
-      relative_app_directory:
-        description: 'The relative path in the repository where the application is built from (defaults to ".")'
-        required: false
-        default: .
-        type: string
       test_dir:
         description: |
           The directory where the Python tests are stored (a `conftest.py` file is expected there).
@@ -80,7 +75,6 @@ jobs:
     with:
       app_repository: ${{ inputs.app_repository }}
       app_branch_name: ${{ inputs.app_branch_name }}
-      relative_app_directory: ${{ inputs.relative_app_directory }}
       compatible_devices: ${{ inputs.run_for_devices }}
       pytest_directory: ${{ inputs.test_dir }}
 


### PR DESCRIPTION
Workflow exemples:
- [guidelines](https://github.com/LedgerHQ/app-boilerplate/actions/runs/6956185159?pr=105)
- [build and test](https://github.com/LedgerHQ/app-boilerplate/actions/runs/6956185160?pr=105)