### PR TITLE
reusable_build.yml: Fix missing maxdepth

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Remove build artifacts before upload
         run: |
-          find ${{ needs.call_get_app_metadata.outputs.build_directory }}/build/ -mindepth 2 -type d ! -name 'bin' -exec rm -r {} +
+          find ${{ needs.call_get_app_metadata.outputs.build_directory }}/build/ -mindepth 2 -maxdepth 2 -type d ! -name 'bin' -exec rm -r {} +
 
       - name: Prepare to upload as lib
         if: ${{ inputs.upload_as_lib_artifact != '' }}


### PR DESCRIPTION
Without this, the cmd delete the directory (obj/ for example) before trying to delete its content, which therefore don't exist anymore.