### PR TITLE
Fix action warnings due to version update

### DIFF
--- a/.github/workflows/_check_app_load_params.yml
+++ b/.github/workflows/_check_app_load_params.yml
@@ -19,21 +19,21 @@ jobs:
 
     steps:
       - name: Clone workflows repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: LedgerHQ/ledger-app-workflows
           path: ./ledger-app-workflows
           ref: ${{ inputs.ledger-app-workflows_ref }}
 
       - name: Clone ledger-app-database repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: LedgerHQ/ledger-app-database
           path: ./ledger-app-database
           ref: main
 
       - name: Download manifest
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.download_manifest_artifact_name }}
           path: ${{ inputs.download_manifest_artifact_name }}

--- a/.github/workflows/_check_clang_static_analyzer.yml
+++ b/.github/workflows/_check_clang_static_analyzer.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload scan result
         if: failure() && ${{ inputs.is_rust == 'false'}}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: scan-build
           path: scan-build

--- a/.github/workflows/_check_clang_static_analyzer_latest_sdk.yml
+++ b/.github/workflows/_check_clang_static_analyzer_latest_sdk.yml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Clone SDK
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: LedgerHQ/ledger-secure-sdk
           path: sdk
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload scan result
         if: failure() && ${{ inputs.is_rust == 'false'}}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: scan-build
           path: scan-build

--- a/.github/workflows/_check_icons.yml
+++ b/.github/workflows/_check_icons.yml
@@ -29,21 +29,21 @@ jobs:
 
     steps:
       - name: Clone workflows repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: LedgerHQ/ledger-app-workflows
           path: ./ledger-app-workflows
           ref: ${{ inputs.ledger-app-workflows_ref }}
 
       - name: Clone app repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.app-repository }}
           path: app-repository
           submodules: recursive
 
       - name: Download manifest
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.download_manifest_artifact_name }}
           path: ${{ inputs.download_manifest_artifact_name }}

--- a/.github/workflows/_check_makefile.yml
+++ b/.github/workflows/_check_makefile.yml
@@ -29,21 +29,21 @@ jobs:
 
     steps:
       - name: Clone workflows repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: LedgerHQ/ledger-app-workflows
           path: ./ledger-app-workflows
           ref: ${{ inputs.ledger-app-workflows_ref }}
 
       - name: Clone app repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.app-repository }}
           path: app-repository
           submodules: recursive
 
       - name: Download manifest
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.download_manifest_artifact_name }}
           path: ${{ inputs.download_manifest_artifact_name }}

--- a/.github/workflows/_check_readme.yml
+++ b/.github/workflows/_check_readme.yml
@@ -25,14 +25,14 @@ jobs:
 
     steps:
       - name: Clone workflows repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: LedgerHQ/ledger-app-workflows
           path: ./ledger-app-workflows
           ref: ${{ inputs.ledger-app-workflows_ref }}
 
       - name: Clone app repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.app-repository }}
           path: app-repository

--- a/.github/workflows/_get_app_manifest.yml
+++ b/.github/workflows/_get_app_manifest.yml
@@ -38,14 +38,14 @@ jobs:
 
     steps:
       - name: Clone workflows repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: LedgerHQ/ledger-app-workflows
           path: ./ledger-app-workflows
           ref: ${{ inputs.ledger-app-workflows_ref }}
 
       - name: Clone app repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: app-repository
           submodules: recursive
@@ -70,7 +70,7 @@ jobs:
               --json_path ../manifest_${{ matrix.device }}.json
 
       - name: Upload app manifest
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.upload_manifest_artifact_name }}
           path: ./manifest_*.json

--- a/.github/workflows/_get_app_metadata.yml
+++ b/.github/workflows/_get_app_metadata.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Clone app repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.app_repository }}
           ref: ${{ inputs.app_branch_name }}

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.app_repository }}
           ref: ${{ inputs.app_branch_name }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload app binary
         if: ${{ inputs.upload_app_binaries_artifact != '' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.upload_app_binaries_artifact }}
           path: ${{ needs.call_get_app_metadata.outputs.build_directory }}/build/*

--- a/.github/workflows/reusable_check_ethereum_sdk.yml
+++ b/.github/workflows/reusable_check_ethereum_sdk.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone plugin
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -29,7 +29,7 @@ jobs:
           fi
 
       - name: Clone SDK
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: LedgerHQ/ethereum-plugin-sdk
           path: plugin-sdk

--- a/.github/workflows/reusable_lint.yml
+++ b/.github/workflows/reusable_lint.yml
@@ -30,11 +30,11 @@ jobs:
     
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Ensure clang-format is customized
         if: ${{ needs.call_get_app_metadata.outputs.is_rust == 'false'}}
-        uses: andstor/file-existence-action@v2
+        uses: andstor/file-existence-action@v3
         with:
           files: ".clang-format"
 

--- a/.github/workflows/reusable_pypi_deployment.yml
+++ b/.github/workflows/reusable_pypi_deployment.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
 
     - name: Clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/reusable_ragger_tests.yml
+++ b/.github/workflows/reusable_ragger_tests.yml
@@ -97,28 +97,28 @@ jobs:
           fi
 
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.app_repository }}
           ref: ${{ inputs.app_branch_name }}
           submodules: recursive
 
       - name: Download app binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.download_app_binaries_artifact }}
           path: ${{ needs.call_get_app_metadata.outputs.build_directory }}/build/
 
       - name: Download additional app binaries if required
         if: ${{ inputs.additional_app_binaries_artifact != '' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.additional_app_binaries_artifact }}
           path: ${{ inputs.additional_app_binaries_artifact_dir }}
 
       - name: Download additional lib binaries if required
         if: ${{ inputs.lib_binaries_artifact != '' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.lib_binaries_artifact }}
           path: ${{ needs.call_get_app_metadata.outputs.pytest_directory }}/lib_binaries/
@@ -137,7 +137,7 @@ jobs:
 
       - name: Upload snapshots
         if: ${{ failure() && inputs.upload_snapshots_on_failure == true }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.device }}-tests-snapshots
           path: ${{ needs.call_get_app_metadata.outputs.pytest_directory }}/snapshots-tmp/${{ matrix.device }}

--- a/.github/workflows/scripts_checking.yml
+++ b/.github/workflows/scripts_checking.yml
@@ -14,7 +14,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
       env:
@@ -26,7 +26,7 @@ jobs:
     name: Check misspellings
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check misspellings
       uses: codespell-project/actions-codespell@v1
       with:


### PR DESCRIPTION
When using the reusable workflows we have warnings like

```
Call Ledger guidelines_enforcer / Dispatch check / Check icons
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/download-artifact@v3
```

```
Call Ledger guidelines_enforcer / Dump app information / Get application manifest for supported devices (nanosp)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/upload-artifact@v3
```

```
Check linting using the reusable workflow / Lint check
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, andstor/file-existence-action@v2
```