### PR TITLE
Revert some action versions

### DIFF
--- a/.github/workflows/_check_app_load_params.yml
+++ b/.github/workflows/_check_app_load_params.yml
@@ -33,7 +33,7 @@ jobs:
           ref: main
 
       - name: Download manifest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.download_manifest_artifact_name }}
           path: ${{ inputs.download_manifest_artifact_name }}

--- a/.github/workflows/_check_clang_static_analyzer.yml
+++ b/.github/workflows/_check_clang_static_analyzer.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload scan result
         if: failure() && ${{ inputs.is_rust == 'false'}}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: scan-build
           path: scan-build

--- a/.github/workflows/_check_clang_static_analyzer_latest_sdk.yml
+++ b/.github/workflows/_check_clang_static_analyzer_latest_sdk.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload scan result
         if: failure() && ${{ inputs.is_rust == 'false'}}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: scan-build
           path: scan-build

--- a/.github/workflows/_check_icons.yml
+++ b/.github/workflows/_check_icons.yml
@@ -43,7 +43,7 @@ jobs:
           submodules: recursive
 
       - name: Download manifest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.download_manifest_artifact_name }}
           path: ${{ inputs.download_manifest_artifact_name }}

--- a/.github/workflows/_check_makefile.yml
+++ b/.github/workflows/_check_makefile.yml
@@ -43,7 +43,7 @@ jobs:
           submodules: recursive
 
       - name: Download manifest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.download_manifest_artifact_name }}
           path: ${{ inputs.download_manifest_artifact_name }}

--- a/.github/workflows/_get_app_manifest.yml
+++ b/.github/workflows/_get_app_manifest.yml
@@ -70,7 +70,7 @@ jobs:
               --json_path ../manifest_${{ matrix.device }}.json
 
       - name: Upload app manifest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.upload_manifest_artifact_name }}
           path: ./manifest_*.json

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload app binary
         if: ${{ inputs.upload_app_binaries_artifact != '' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.upload_app_binaries_artifact }}
           path: ${{ needs.call_get_app_metadata.outputs.build_directory }}/build/*

--- a/.github/workflows/reusable_ragger_tests.yml
+++ b/.github/workflows/reusable_ragger_tests.yml
@@ -104,21 +104,21 @@ jobs:
           submodules: recursive
 
       - name: Download app binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.download_app_binaries_artifact }}
           path: ${{ needs.call_get_app_metadata.outputs.build_directory }}/build/
 
       - name: Download additional app binaries if required
         if: ${{ inputs.additional_app_binaries_artifact != '' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.additional_app_binaries_artifact }}
           path: ${{ inputs.additional_app_binaries_artifact_dir }}
 
       - name: Download additional lib binaries if required
         if: ${{ inputs.lib_binaries_artifact != '' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.lib_binaries_artifact }}
           path: ${{ needs.call_get_app_metadata.outputs.pytest_directory }}/lib_binaries/
@@ -137,7 +137,7 @@ jobs:
 
       - name: Upload snapshots
         if: ${{ failure() && inputs.upload_snapshots_on_failure == true }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.device }}-tests-snapshots
           path: ${{ needs.call_get_app_metadata.outputs.pytest_directory }}/snapshots-tmp/${{ matrix.device }}


### PR DESCRIPTION

From the Action main page https://github.com/actions/upload-artifact, we can see:
`Unlike earlier versions of upload-artifact, uploading to the same artifact via multiple jobs is not supported with v4.`

Revert action version for upload and download to v3.