### PR TITLE
Add new input to ragger workflow to pass a custom test option

### DIFF
--- a/.github/workflows/reusable_ragger_tests.yml
+++ b/.github/workflows/reusable_ragger_tests.yml
@@ -64,6 +64,11 @@ on:
         required: false
         default: '""'
         type: string
+      test_options:
+        description: 'Specify optional parameters to be passed to the running test'
+        required: false
+        default: '""'
+        type: string
 
 jobs:
   call_get_app_metadata:
@@ -155,7 +160,7 @@ jobs:
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
           PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
-        run: pytest ${{ needs.call_get_app_metadata.outputs.pytest_directory }}/ --tb=short -v --device ${{ matrix.device }} -k ${{ inputs.test_filter }}
+        run: pytest ${{ needs.call_get_app_metadata.outputs.pytest_directory }}/ --tb=short -v --device ${{ matrix.device }} -k ${{ inputs.test_filter }} ${{ inputs.test_options }}
 
       - name: Upload snapshots
         if: ${{ failure() && inputs.upload_snapshots_on_failure == true }}


### PR DESCRIPTION
This allows to use such config in a CI:

```
  ragger_tests_3:
    needs: build_application
    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_ragger_tests.yml@v1
    with:
      download_app_binaries_artifact: "ragger_elfs"
      test_filter: "'test_1559'"
      test_options: "-s -v"
```

And any other command line parameters, linked to specific test condition can be used.
