### PR TITLE
Revert "Add new input to ragger workflow to pass a custom test option"

### DIFF
--- a/.github/workflows/reusable_ragger_tests.yml
+++ b/.github/workflows/reusable_ragger_tests.yml
@@ -67,7 +67,7 @@ on:
       test_options:
         description: 'Specify optional parameters to be passed to the running test'
         required: false
-        default: '""'
+        default: ''
         type: string
 
 jobs:


### PR DESCRIPTION
Change default value for the parameter `test_options`.