### PR TITLE
Add top script to run the different Rule Enforcer scripts

### DIFF
--- a/.github/workflows/_check_app_load_params.yml
+++ b/.github/workflows/_check_app_load_params.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Clone workflows repository
+      - name: Clone ledger-app-workflows repository
         uses: actions/checkout@v4
         with:
           repository: LedgerHQ/ledger-app-workflows
@@ -40,6 +40,6 @@ jobs:
 
       - name: Run script
         run: |
-          python3 ./ledger-app-database/scripts/app_load_params_check.py \
-          --database_path ./ledger-app-database/app-load-params-db.json \
-          --app_manifests_path ${{ inputs.download_manifest_artifact_name }}
+            ./ledger-app-workflows/scripts/check_all.sh \
+              -c app_load_params -d ./ledger-app-database \
+              -m ${{ inputs.download_manifest_artifact_name }}

--- a/.github/workflows/_check_clang_static_analyzer.yml
+++ b/.github/workflows/_check_clang_static_analyzer.yml
@@ -3,6 +3,15 @@ name: Run Clang Static Analyzer
 on:
   workflow_call:
     inputs:
+      ledger-app-workflows_ref:
+        description: 'The current reference in use for the ledger-app-workflow repository'
+        required: true
+        type: string
+      app-repository:
+        description: 'The URL of the app repository to check. Defaults to the workflow caller repository URL'
+        required: false
+        default: ${{ github.repository }}
+        type: string
       run_for_devices:
         description: 'The list of device(s) on which the checking will run'
         required: true
@@ -29,24 +38,32 @@ jobs:
       image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
 
     steps:
-      - name: Clone
+      - name: Clone ledger-app-workflows repository
         uses: actions/checkout@v4
         with:
+          repository: LedgerHQ/ledger-app-workflows
+          path: ./ledger-app-workflows
+          ref: ${{ inputs.ledger-app-workflows_ref }}
+
+      - name: Clone app repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.app-repository }}
+          path: app-repository
           submodules: recursive
 
       - name: Run Clippy
         if: ${{ inputs.is_rust == 'true'}}
         run: |
-          cd ${{ inputs.relative_app_directory }} && \
-          DEVICE_NAME="$(echo ${{ matrix.device }} | sed 's/nanosp/nanosplus/')" && \
-          cargo +$RUST_NIGHTLY clippy --target ${DEVICE_NAME} -- -Dwarnings
+            ./ledger-app-workflows/scripts/check_all.sh -r -c scan -t ${{ matrix.device }} \
+              -a ./app-repository -b ${{ inputs.relative_app_directory }}
 
       - name: Build with Clang Static Analyzer
         if: ${{ inputs.is_rust == 'false'}}
         run: |
-          eval "BOLOS_SDK=\$$(echo ${{ matrix.device }} | tr [:lower:] [:upper:])_SDK" && \
-          echo "BOLOS_SDK value will be: ${BOLOS_SDK}" && \
-          make -C ${{ inputs.relative_app_directory }} -j ENABLE_SDK_WERROR=1 BOLOS_SDK=${BOLOS_SDK} scan-build
+            eval "BOLOS_SDK=\$$(echo ${{ matrix.device }} | tr [:lower:] [:upper:])_SDK" && \
+            ./ledger-app-workflows/scripts/check_all.sh -c scan -t ${{ matrix.device }} \
+              -a ./app-repository -b ${{ inputs.relative_app_directory }}
 
       - name: Upload scan result
         if: failure() && ${{ inputs.is_rust == 'false'}}

--- a/.github/workflows/_check_clang_static_analyzer_latest_sdk.yml
+++ b/.github/workflows/_check_clang_static_analyzer_latest_sdk.yml
@@ -3,6 +3,15 @@ name: Run Clang Static Analyzer (master SDK)
 on:
   workflow_call:
     inputs:
+      ledger-app-workflows_ref:
+        description: 'The current reference in use for the ledger-app-workflow repository'
+        required: true
+        type: string
+      app-repository:
+        description: 'The URL of the app repository to check. Defaults to the workflow caller repository URL'
+        required: false
+        default: ${{ github.repository }}
+        type: string
       run_for_devices:
         description: 'The list of device(s) on which the checking will run'
         required: true
@@ -29,9 +38,18 @@ jobs:
       image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
 
     steps:
-      - name: Clone
+      - name: Clone ledger-app-workflows repository
         uses: actions/checkout@v4
         with:
+          repository: LedgerHQ/ledger-app-workflows
+          path: ./ledger-app-workflows
+          ref: ${{ inputs.ledger-app-workflows_ref }}
+
+      - name: Clone app repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.app-repository }}
+          path: app-repository
           submodules: recursive
 
       - name: Clone SDK
@@ -44,9 +62,9 @@ jobs:
       - name: Build with Clang Static Analyzer
         if: ${{ inputs.is_rust == 'false'}}
         run: |
-          DEVICE_NAME=$(echo ${{ matrix.device }} | sed 's/nanosp/nanos2/') && \
-          echo "TARGET value will be: ${DEVICE_NAME}" && \
-          make -C ${{ inputs.relative_app_directory }} -j ENABLE_SDK_WERROR=1 BOLOS_SDK=${GITHUB_WORKSPACE}/sdk TARGET=${DEVICE_NAME} scan-build
+            BOLOS_SDK=${GITHUB_WORKSPACE}/sdk && \
+            ./ledger-app-workflows/scripts/check_all.sh -c scan -t ${{ matrix.device }} \
+              -a ./app-repository -b ${{ inputs.relative_app_directory }}
 
       - name: Upload scan result
         if: failure() && ${{ inputs.is_rust == 'false'}}

--- a/.github/workflows/_check_icons.yml
+++ b/.github/workflows/_check_icons.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Clone workflows repository
+      - name: Clone ledger-app-workflows repository
         uses: actions/checkout@v4
         with:
           repository: LedgerHQ/ledger-app-workflows
@@ -49,4 +49,6 @@ jobs:
           path: ${{ inputs.download_manifest_artifact_name }}
 
       - name: Run script
-        run: bash ./ledger-app-workflows/scripts/check_icons.sh app-repository ${{ inputs.repo-name }} ${{ inputs.download_manifest_artifact_name }}
+        run: |
+            ./ledger-app-workflows/scripts/check_all.sh -c icons \
+              -a ./app-repository -m ${{ inputs.download_manifest_artifact_name }}

--- a/.github/workflows/_check_makefile.yml
+++ b/.github/workflows/_check_makefile.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Clone workflows repository
+      - name: Clone ledger-app-workflows repository
         uses: actions/checkout@v4
         with:
           repository: LedgerHQ/ledger-app-workflows
@@ -49,4 +49,6 @@ jobs:
           path: ${{ inputs.download_manifest_artifact_name }}
 
       - name: Run script
-        run: bash ./ledger-app-workflows/scripts/check_makefile.sh app-repository ${{ inputs.repo-name }} ${{ inputs.download_manifest_artifact_name }}
+        run: |
+            ./ledger-app-workflows/scripts/check_all.sh -c makefile \
+              -a ./app-repository -m ${{ inputs.download_manifest_artifact_name }}

--- a/.github/workflows/_check_readme.yml
+++ b/.github/workflows/_check_readme.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Clone workflows repository
+      - name: Clone ledger-app-workflows repository
         uses: actions/checkout@v4
         with:
           repository: LedgerHQ/ledger-app-workflows
@@ -39,4 +39,5 @@ jobs:
           submodules: recursive
 
       - name: Run script
-        run: bash ./ledger-app-workflows/scripts/check_readme.sh app-repository ${{ inputs.repo-name }}
+        run: |
+            ./ledger-app-workflows/scripts/check_all.sh -c readme -a ./app-repository

--- a/.github/workflows/_get_app_manifest.yml
+++ b/.github/workflows/_get_app_manifest.yml
@@ -7,6 +7,11 @@ on:
         description: 'The current reference in use for the ledger-app-workflow repository'
         required: true
         type: string
+      app-repository:
+        description: 'The URL of the app repository to check. Defaults to the workflow caller repository URL'
+        required: false
+        default: ${{ github.repository }}
+        type: string
       run_for_devices:
         description: 'The list of device(s) on which the checking will run'
         required: true
@@ -37,7 +42,7 @@ jobs:
       image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
 
     steps:
-      - name: Clone workflows repository
+      - name: Clone ledger-app-workflows repository
         uses: actions/checkout@v4
         with:
           repository: LedgerHQ/ledger-app-workflows
@@ -47,27 +52,24 @@ jobs:
       - name: Clone app repository
         uses: actions/checkout@v4
         with:
+          repository: ${{ inputs.app-repository }}
           path: app-repository
           submodules: recursive
 
       - name: Call Cargo metadata dumper script
         if: ${{ inputs.is_rust == 'true'}}
         run: |
-          cd app-repository && \
-          BOLOS_SDK=${BOLOS_SDK} python ../ledger-app-workflows/scripts/cargo_metadata_dump.py \
-              --device ${{ matrix.device }} \
-              --app_build_path ${{ inputs.relative_app_directory }} \
-              --json_path ../manifest_${{ matrix.device }}.json
+            ./ledger-app-workflows/scripts/check_all.sh -r -c manifest -t ${{ matrix.device }} \
+              -a ./app-repository -b ${{ inputs.relative_app_directory }} \
+              -m ../manifest_${{ matrix.device }}.json
 
       - name: Call Makefile dumper script
         if: ${{ inputs.is_rust == 'false'}}
         run: |
-          cd app-repository && \
-          eval "BOLOS_SDK=\$$(echo ${{ matrix.device }} | tr [:lower:] [:upper:])_SDK" && \
-          echo "BOLOS_SDK value will be: ${BOLOS_SDK}" && \
-          BOLOS_SDK=${BOLOS_SDK} python ../ledger-app-workflows/scripts/makefile_dump.py \
-              --app_build_path ${{ inputs.relative_app_directory }} \
-              --json_path ../manifest_${{ matrix.device }}.json
+            eval "BOLOS_SDK=\$$(echo ${{ matrix.device }} | tr [:lower:] [:upper:])_SDK" && \
+            ./ledger-app-workflows/scripts/check_all.sh -c manifest -t ${{ matrix.device }} \
+              -a ./app-repository -b ${{ inputs.relative_app_directory }} \
+              -m ../manifest_${{ matrix.device }}.json
 
       - name: Upload app manifest
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_get_app_metadata.yml
+++ b/.github/workflows/_get_app_metadata.yml
@@ -72,47 +72,47 @@ jobs:
       - name: Gather application metadata, from inputs or 'ledger_app.toml'
         id: fetch_metadata
         run: |
-          pytest_directory='${{ inputs.pytest_directory }}';
+          pytest_directory='${{ inputs.pytest_directory }}'
           if [[ ! -f "$APP_MANIFEST" ]];
           then
-              >&2 echo "/!\ No $APP_MANIFEST manifest detected!";
-              >&2 echo "This file is mandatory, please add it on your repository";
-              >&2 echo "Documentation here: https://github.com/LedgerHQ/ledgered/blob/master/doc/utils/manifest.md";
-              exit 1;
+              >&2 echo "/!\ No $APP_MANIFEST manifest detected!"
+              >&2 echo "This file is mandatory, please add it on your repository"
+              >&2 echo "Documentation here: https://github.com/LedgerHQ/ledgered/blob/master/doc/utils/manifest.md"
+              exit 1
           fi
 
           # 'ledger_app.toml' exists
-          echo "Manifest detected.";
+          echo "Manifest detected."
           # checking the manifest with the repo
-          ledger-manifest --check . "$APP_MANIFEST";
+          ledger-manifest --check . "$APP_MANIFEST"
 
           # build directory
-          echo "build_directory=$(ledger-manifest --output-build-directory "$APP_MANIFEST")" >> "$GITHUB_OUTPUT";
+          echo "build_directory=$(ledger-manifest --output-build-directory "$APP_MANIFEST")" >> "$GITHUB_OUTPUT"
 
           # get device list as a single line json formatted value
-          compatible_devices="$(ledger-manifest --output-devices "$APP_MANIFEST" -j | jq -rc '.devices')";
+          compatible_devices="$(ledger-manifest --output-devices "$APP_MANIFEST" -j | jq -rc '.devices')"
           if [[ '${{ inputs.compatible_devices }}' != 'None' ]];
           then
               # in case classic manifest with devices, the input takes precedence on it
-              compatible_devices='${{ inputs.compatible_devices }}';
+              compatible_devices='${{ inputs.compatible_devices }}'
           fi
-          echo "compatible_devices=${compatible_devices}" | sed 's/+/p/' >> "$GITHUB_OUTPUT";
+          echo "compatible_devices=${compatible_devices}" | sed 's/+/p/' >> "$GITHUB_OUTPUT"
 
           # pytest_directory (if any)
           set +e  # when [tests.pytest_directory] is not set, ledger-manifest fails. We don't want that
           if temp="$(ledger-manifest --output-tests-pytest-directory "$APP_MANIFEST")";
           then
-              pytest_directory="${temp}";
+              pytest_directory="${temp}"
           fi
           set -e
-          echo "pytest_directory=${pytest_directory}" >> "$GITHUB_OUTPUT";
+          echo "pytest_directory=${pytest_directory}" >> "$GITHUB_OUTPUT"
 
           # SDK language
           if [[ "$(ledger-manifest --output-sdk "$APP_MANIFEST")" == "rust" ]];
           then
-              echo "is_rust=true" >> "$GITHUB_OUTPUT";
+              echo "is_rust=true" >> "$GITHUB_OUTPUT"
           else
-              echo "is_rust=false" >> "$GITHUB_OUTPUT";
+              echo "is_rust=false" >> "$GITHUB_OUTPUT"
           fi
 
           echo "Inferred metadata:"

--- a/.github/workflows/reusable_guidelines_enforcer.yml
+++ b/.github/workflows/reusable_guidelines_enforcer.yml
@@ -3,6 +3,11 @@ name: Ensure app compliance with Ledger guidelines
 on:
   workflow_call:
     inputs:
+      app_repository:
+        description: 'The GIT repository to build (defaults to `github.repository`)'
+        required: false
+        default: ${{ github.repository }}
+        type: string
       run_for_devices:
         description: |
           The list of device(s) on which the test will run.
@@ -38,6 +43,7 @@ jobs:
     name: Retrieve application metadata
     uses: ./.github/workflows/_get_app_metadata.yml
     with:
+      app_repository: ${{ inputs.app_repository }}
       compatible_devices: ${{ inputs.run_for_devices }}
 
   call_get_app_manifest:
@@ -45,6 +51,7 @@ jobs:
     needs: [call_get_workflow_version, call_get_app_metadata]
     uses: ./.github/workflows/_get_app_manifest.yml
     with:
+      app-repository: ${{ inputs.app_repository }}
       ledger-app-workflows_ref: ${{ needs.call_get_workflow_version.outputs.version }}
       run_for_devices: ${{ needs.call_get_app_metadata.outputs.compatible_devices }}
       relative_app_directory: ${{ needs.call_get_app_metadata.outputs.build_directory }}
@@ -56,6 +63,7 @@ jobs:
     needs: [call_get_workflow_version, call_get_app_manifest]
     uses: ./.github/workflows/_check_icons.yml
     with:
+      app-repository: ${{ inputs.app_repository }}
       download_manifest_artifact_name: manifests
       ledger-app-workflows_ref: ${{ needs.call_get_workflow_version.outputs.version }}
 
@@ -72,6 +80,7 @@ jobs:
     needs: [call_get_workflow_version, call_get_app_manifest]
     uses: ./.github/workflows/_check_makefile.yml
     with:
+      app-repository: ${{ inputs.app_repository }}
       download_manifest_artifact_name: manifests
       ledger-app-workflows_ref: ${{ needs.call_get_workflow_version.outputs.version }}
 
@@ -80,23 +89,28 @@ jobs:
     needs: call_get_workflow_version
     uses: ./.github/workflows/_check_readme.yml
     with:
+      app-repository: ${{ inputs.app_repository }}
       ledger-app-workflows_ref: ${{ needs.call_get_workflow_version.outputs.version }}
 
   call_clang_static_analyzer:
     name: Dispatch check
-    needs: call_get_app_metadata
+    needs: [call_get_app_metadata, call_get_workflow_version]
     uses: ./.github/workflows/_check_clang_static_analyzer.yml
     with:
+      app-repository: ${{ inputs.app_repository }}
       run_for_devices: ${{ needs.call_get_app_metadata.outputs.compatible_devices }}
       relative_app_directory: ${{ needs.call_get_app_metadata.outputs.build_directory }}
       is_rust: ${{ needs.call_get_app_metadata.outputs.is_rust }}
+      ledger-app-workflows_ref: ${{ needs.call_get_workflow_version.outputs.version }}
 
   call_clang_static_analyzer_latest_sdk:
     name: Dispatch check
-    needs: call_get_app_metadata
+    needs: [call_get_app_metadata, call_get_workflow_version]
     uses: ./.github/workflows/_check_clang_static_analyzer_latest_sdk.yml
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'scan_on_latest_sdk')
     with:
+      app-repository: ${{ inputs.app_repository }}
       run_for_devices: ${{ needs.call_get_app_metadata.outputs.compatible_devices }}
       relative_app_directory: ${{ needs.call_get_app_metadata.outputs.build_directory }}
       is_rust: ${{ needs.call_get_app_metadata.outputs.is_rust }}
+      ledger-app-workflows_ref: ${{ needs.call_get_workflow_version.outputs.version }}

--- a/.github/workflows/reusable_ragger_tests.yml
+++ b/.github/workflows/reusable_ragger_tests.yml
@@ -186,7 +186,7 @@ jobs:
         if: ${{ failure() && inputs.upload_snapshots_on_failure == true }}
         uses: actions/upload-artifact@v4
         with:
-          # Make the artifact name unique to allow running this job in parrallel
+          # Make the artifact name unique to allow running this job in parallel
           name: tests_snapshots${{ inputs.test_options }}-${{ matrix.device }}
           path: ${{ needs.call_get_app_metadata.outputs.pytest_directory }}/snapshots-tmp
 

--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+#
+# script to run Guideline_enforcer checks
+#
+
+exeName=$(readlink -f "$0")
+dirName=$(dirname "${exeName}")
+
+# shellcheck source=/dev/null
+source "${dirName}/logger.sh"
+
+VERBOSE=false
+IS_RUST=false
+
+# All available checks ('manifest' must be the first one)
+ALL_CHECKS="manifest icons app_load_params makefile readme scan"
+
+#===============================================================================
+#
+#     help - Prints script help and usage
+#
+#===============================================================================
+# shellcheck disable=SC2154  # var is referenced but not assigned
+help() {
+    local err="$1"
+
+    [[ -n "${err}" ]] && log_error "${err}"
+
+    echo
+    echo "Usage: ${exeName} <options>"
+    echo
+    echo "Options:"
+    echo
+    echo "  -c <check>  : Requested check from (${ALL_CHECKS}). Default is all."
+    echo "  -d <dir>    : Database directory"
+    echo "  -a <dir>    : Application directory"
+    echo "  -b <dir>    : Application build directory"
+    echo "  -m <file>   : Manifest (file or directory)"
+    echo "  -t <device> : Targeted device"
+    echo "  -r          : Rust application"
+    echo "  -v          : Verbose mode"
+    echo "  -h          : Displays this help"
+    echo
+    exit 1
+}
+
+#===============================================================================
+#
+#     Parsing parameters
+#
+#===============================================================================
+
+while getopts ":a:b:c:d:m:t:rvh" opt; do
+    case ${opt} in
+        a)  APP_DIR=${OPTARG}   ;;
+        b)  BUILD_DIR=${OPTARG} ;;
+        c)  REQUESTED_CHECK=${OPTARG} ;;
+        d)  DATABASE_DIR=${OPTARG} ;;
+        m)  MANIFEST=${OPTARG}  ;;
+        t)  TARGET=${OPTARG}    ;;
+        r)  IS_RUST=true ;;
+        v)  VERBOSE=true ;;
+        h)  help ;;
+
+        \?) echo "Unknown option: -${OPTARG}" >&2; exit 1;;
+        : ) echo "Missing option argument for -${OPTARG}" >&2; exit 1;;
+        * ) echo "Unimplemented option: -${OPTARG}" >&2; exit 1;;
+    esac
+done
+
+#===============================================================================
+#
+#     Checking parameters
+#
+#===============================================================================
+
+# Check if the requested check is valid
+if [[ -n ${REQUESTED_CHECK} ]]; then
+    [[ $(wc -w <<< "${REQUESTED_CHECK}") -ne 1 ]] && help "Too many checks requested!"
+    [[ ! "${ALL_CHECKS}" =~ ${REQUESTED_CHECK} ]] && help "Unknown check: ${REQUESTED_CHECK}"
+fi
+if [[ (-z ${REQUESTED_CHECK}) || ("${REQUESTED_CHECK}" =~ (manifest|scan)) ]]; then
+    # Check BUILD_DIR environment variable
+    [[ -z ${BUILD_DIR} ]] && help "Missing mandatory parameter 'Build directory'!"
+fi
+
+if [[ "${REQUESTED_CHECK}" != app_load_params ]]; then
+    # Check if APP_DIR is given in parameter
+    [[ -z "${APP_DIR}" ]] && help "Missing mandatory parameter 'Application directory'!"
+    # Check if REPO_NAME is given in parameter
+    REPO_NAME=$(basename "$(git -C "${APP_DIR}" remote get-url origin)")
+    REPO_NAME=${REPO_NAME%%.*}
+fi
+
+# Init verbose options
+make_option=(-j -C "${APP_DIR}/${BUILD_DIR}")
+if [[ ${VERBOSE} == false ]]; then
+    make_option+=(-s --no-print-directory)
+    verbose_mode=(-q)
+fi
+
+# Check if TARGET is already setup
+if [[ (-z ${TARGET}) && ("${REQUESTED_CHECK}" =~ (manifest|scan)) ]]; then
+    TARGET=$(make "${make_option[@]}" listinfo 2>/dev/null | grep -w TARGET | cut -d'=' -f2)
+fi
+
+# Check if MANIFEST is given in parameter
+if [[ -z ${MANIFEST} ]]; then
+    if [[ -z ${TARGET} ]]; then
+        MANIFEST_FILE="/tmp/manifests/manifest.json"
+    else
+        MANIFEST_FILE="/tmp/manifests/manifest_${TARGET}.json"
+    fi
+    MANIFEST_DIR=$(dirname "${MANIFEST_FILE}")
+    # Remove the directory if it already exists
+    [[ -d "${MANIFEST_DIR}" ]] && rm -rf "${MANIFEST_DIR}"
+    mkdir -p "${MANIFEST_DIR}"
+else
+    if [[ -d "${MANIFEST}" ]]; then
+        MANIFEST_FILE="${MANIFEST}/manifest.json"
+    else
+        MANIFEST_FILE="${MANIFEST}"
+    fi
+    MANIFEST_DIR=$(dirname "${MANIFEST_FILE}")
+fi
+
+if [[ (-z ${REQUESTED_CHECK}) || ("${REQUESTED_CHECK}" == app_load_params) ]]; then
+    if [[ -z "${DATABASE_DIR}" ]]; then
+        # Check if DATABASE_DIR is already present
+        DATABASE_DIR="/tmp/ledger-app-database"
+        git clone "${verbose_mode[@]}" https://github.com/LedgerHQ/ledger-app-database.git "${DATABASE_DIR}"
+    fi
+fi
+
+#===============================================================================
+#
+#     log functions
+#
+#===============================================================================
+BG_TITLE="\e[48;6;3;1;44m"
+FG_TITLE="\e[38;5;44m"
+
+(( STEP=1 ))
+log_step() {
+    echo
+    _log_colored_line "$BG_WARNING" "[STEP ${STEP}]: " "$FG_WARNING" "$1"
+    (( STEP++ ))
+}
+
+log_title() {
+    echo
+    _log_colored_line "$BG_TITLE" "Starting: " "$FG_TITLE" "$1"
+}
+
+#===============================================================================
+#
+#     step function
+#
+#===============================================================================
+
+call_step() {
+    local step="$1"
+
+    case ${step} in
+        "manifest")
+            if [[ "${IS_RUST}" == true ]]; then
+                COMMAND="(cd ${APP_DIR} && python ${dirName}/cargo_metadata_dump.py --device ${TARGET} --app_build_path ${BUILD_DIR} --json_path ${MANIFEST_FILE})"
+            else
+                COMMAND="(cd ${APP_DIR} && python ${dirName}/makefile_dump.py --app_build_path ${BUILD_DIR} --json_path ${MANIFEST_FILE})"
+            fi
+            ;;
+        "icons")
+            COMMAND="${dirName}/check_icons.sh ${APP_DIR} ${REPO_NAME} ${MANIFEST_DIR}"
+            ;;
+        "app_load_params")
+            COMMAND="python ${DATABASE_DIR}/scripts/app_load_params_check.py --database_path ${DATABASE_DIR}/app-load-params-db.json --app_manifests_path ${MANIFEST_DIR}"
+            ;;
+        "makefile")
+            COMMAND="${dirName}/check_makefile.sh ${APP_DIR} ${REPO_NAME} ${MANIFEST_DIR}"
+            ;;
+        "readme")
+            COMMAND="${dirName}/check_readme.sh ${APP_DIR} ${REPO_NAME}"
+            ;;
+        "scan")
+            if [[ "${IS_RUST}" == true ]]; then
+                COMMAND="(cd ${APP_DIR}/${BUILD_DIR} && cargo +$RUST_NIGHTLY clippy --target ${TARGET/nanosp/nanosplus} -- -Dwarnings)"
+            else
+                COMMAND="make ${make_option[*]} ENABLE_SDK_WERROR=1 scan-build 2>/dev/null"
+            fi
+            ;;
+        * ) echo "Unimplemented step: ${step}" >&2; exit 1;;
+    esac
+
+    if [[ "${step}" == manifest ]]; then
+        log_step "Get ${step}"
+    else
+        log_step "Check ${step}"
+    fi
+
+    [[ "${VERBOSE}" == true ]] && echo "Running: ${COMMAND}"
+    eval "${COMMAND}"
+    err=$?
+    if [[ ${err} -ne 0 ]]; then
+        log_error "Check ${step} failed"
+        exit 1
+    fi
+}
+
+#===============================================================================
+#
+#     Main
+#
+#===============================================================================
+
+if [[ -z "${TARGET}" ]]; then
+    log_title "Running Guideline_enforcer checks"
+else
+    log_title "Running Guideline_enforcer checks for '${TARGET}'"
+fi
+
+if [[ -z ${REQUESTED_CHECK} ]]; then
+    REQUESTED_CHECK="${ALL_CHECKS}"
+else
+    # 1st mandatory step to retrieve the app configuration if directory is empty
+    if [[ ("${REQUESTED_CHECK}" =~ (icons|app_load_params|makefile) ) && ( ! $( ls -A "${MANIFEST_DIR}")) ]]; then
+        call_step "manifest"
+    fi
+fi
+
+# Run requested checks
+for check in ${REQUESTED_CHECK}; do
+    call_step "${check}"
+done
+
+echo
+if [[ -z "${TARGET}" ]]; then
+    log_success "Successfully ran Guideline_enforcer checks"
+else
+    log_success "Successfully ran Guideline_enforcer checks for '${TARGET}'"
+fi

--- a/scripts/check_readme.sh
+++ b/scripts/check_readme.sh
@@ -35,8 +35,8 @@ main() (
         log_error_no_header "At least one error has been found"
         log_error_no_header "To check the Readme content, run \"cat '$repo/README.md'\""
     fi
-	
-    
+
+
     if echo "$repo_name" | grep -q "app.*boilerplate"; then
         log_warning "App specification check skipped for Boilerplate"
     else
@@ -47,7 +47,7 @@ main() (
             fi
         fi
     fi
-	
+
     return "$error"
 )
 


### PR DESCRIPTION
Add a top script gathering the different check commands in a single place.
This script can be called from the command line, locally or inside a docker.

This is the 1st step to be able to run the equivalent of the Guideline Enforcer workflow from VSCode extension.

This has been tested using the following apps triggering this branch (in a draft PR):
- app-boilerplate
- app-boilerplate-rust
- app-plugin-boilerplate
- app-ethereum
- app-flow
