### PR TITLE
Fix icons check for all targets

### DIFF
--- a/.github/workflows/end_to_end_tests_of_reusable_workflows.yml
+++ b/.github/workflows/end_to_end_tests_of_reusable_workflows.yml
@@ -72,6 +72,9 @@ jobs:
           - name: ton
             repo: 'LedgerHQ/app-ton-new'
             branch: 'develop'
+          - name: cardano
+            repo: 'LedgerHQ/app-cardano'
+            branch: 'develop'
 
     uses: ./.github/workflows/reusable_build.yml
     with:


### PR DESCRIPTION
In case we want to run the script ouside the CI (VSCode extension or manually), the icon check was only taking into account the device pointed by the environment variable `BOLOS_SDK`.

Here, when not specified, we perform a loop on all supported devices to generate all the required manifest, and thus check all icons at once

Additional commit to add the cardano app to the E-2-E swap tests :wink: 