### PR TITLE
Allow 'secret' options to be given to pytest in the reusable Ragger workflow

### DIFF
--- a/.github/workflows/end_to_end_tests_of_reusable_workflows.yml
+++ b/.github/workflows/end_to_end_tests_of_reusable_workflows.yml
@@ -78,6 +78,15 @@ jobs:
           - name: near
             repo: 'LedgerHQ/app-near'
             branch: 'develop'
+          - name: APTOS
+            repo: 'LedgerHQ/app-aptos'
+            branch: 'develop'
+          - name: sui
+            repo: 'LedgerHQ/app-sui'
+            branch: 'develop'
+          - name: ATOM
+            repo: 'LedgerHQ/app-cosmos'
+            branch: 'develop'
 
     uses: ./.github/workflows/reusable_build.yml
     with:

--- a/.github/workflows/reusable_ragger_tests.yml
+++ b/.github/workflows/reusable_ragger_tests.yml
@@ -79,6 +79,10 @@ on:
         required: false
         default: ''
         type: string
+    secrets:
+      secret_test_options:
+        description: 'A string of secret options to be given to `pytest`'
+        required: false
 jobs:
   call_get_app_metadata:
     # This job digests inputs and repository metadata provided by the `ledger_app.toml` manifest
@@ -190,6 +194,7 @@ jobs:
                  --device ${{ matrix.device }} \
                  -k ${{ inputs.test_filter }} \
                  ${{ inputs.test_options }} \
+                 ${{ secrets.secret_test_options }} \
                  ${{ inputs.regenerate_snapshots == true && '--golden_run' || '' }}
 
       - name: Upload snapshots on failure if needed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# To install hooks, run:
+# pre-commit install --hook-type pre-commit
+# pre-commit install --hook-type commit-msg
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files


### PR DESCRIPTION
Some application (specifically Security Key) give secret option to `pytest` when running the tests.
These secrets are stored in the GitHub repo and can be accessed through classic `${{ secrets.name }}`

However currently the only way to pass argument in the reusable workflow is through a workflow *input*, `test_options`. GitHub seems to not allow to pass `secrets` there, probably because they would end up in clear text.

This PR proposes a solution for this, by adding a workflow *secret* (and not *input*) `secret_test_options`, which is also feed to `pytest`.
This way, it is possible to pass secret arguments to `pytest` in the reusable workflow (and they remain hidden).

Example [here](https://github.com/LedgerHQ/app-security-key/actions/runs/13331761370/job/37237474851).