### PR TITLE
Add jq installation to reusable build for Rust CI

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -91,6 +91,7 @@ jobs:
         run: |
           if [ "${{ needs.call_get_app_metadata.outputs.is_rust }}" = "true" ];
           then
+              apt install jq --no-install-recommends -y
               BUILD_DEVICE_NAME="$(echo ${{ matrix.device }} | sed 's/nanosp/nanosplus/')" && \
               cd ${{ needs.call_get_app_metadata.outputs.build_directory }}
               # Update the Rust SDK crates


### PR DESCRIPTION
:rotating_light:  To be merged in sync with the migration to Debian-based builders. :rotating_light: 