### PR TITLE
Bump default lint version to clang-format 14

### DIFF
--- a/.github/workflows/reusable_lint.yml
+++ b/.github/workflows/reusable_lint.yml
@@ -9,7 +9,7 @@ on:
       version:
         required: false
         type: number
-        default: 11
+        default: 14
       extensions:
         required: false
         default: 'h,c,proto'


### PR DESCRIPTION
Now that the app-builder comes with LLVM 14