### PR TITLE
Add new reusable workflows for unit-test, codeql and python-check

### DIFF
--- a/.github/workflows/reusable_codeql_checks.yml
+++ b/.github/workflows/reusable_codeql_checks.yml
@@ -1,0 +1,114 @@
+name: Build the application for all devices and upload the artifact
+
+on:
+  workflow_call:
+    inputs:
+      app_repository:
+        description: 'The GIT repository to build (defaults to `github.repository`)'
+        required: false
+        default: ${{ github.repository }}
+        type: string
+      app_branch_name:
+        description: 'The GIT branch to build (defaults to `github.ref`)'
+        required: false
+        default: ${{ github.ref }}
+        type: string
+      run_for_devices:
+        description: |
+          The list of device(s) on which the CI will run.
+
+          Defaults to the full list of device(s) supported by the application as configured in the
+          'ledger_app.toml' manifest.
+          If the manifest is missing, defaults to ALL (["nanos", "nanox", "nanosp", "stax", "flex", "apex_m", "apex_p"]).
+        required: false
+        default: 'None'
+        type: string
+      builder:
+        description: "The docker image to build the application in (defaults to ledger-app-builder-lite)"
+        required: false
+        default: 'ledger-app-builder-lite'
+        type: string
+      flags:
+        description: "Additional flags (default to none)"
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  call_get_app_metadata:
+    # This job digests inputs and repository metadata provided by the `ledger_app.toml` manifest
+    # file, in order to output relevant compatible devices needed by following jobs.
+    name: Retrieve application metadata
+    uses: ./.github/workflows/_get_app_metadata.yml
+    with:
+      app_repository: ${{ inputs.app_repository }}
+      app_branch_name: ${{ inputs.app_branch_name }}
+      compatible_devices: ${{ inputs.run_for_devices }}
+    secrets:
+      token: ${{ secrets.token }}
+
+  build_device_matrix:
+    name: Build device matrix
+    needs: call_get_app_metadata
+    runs-on: ubuntu-latest
+    outputs:
+      sdks_config: ${{ steps.sdk_list.outputs.sdks_config }}
+
+    steps:
+      - name: Define the list of devices to target
+        id: sdk_list
+        shell: bash
+        run: |
+          if [ "${{ inputs.run_for_devices }}" = "None" ]; then
+            # Use the compatible devices from metadata
+            devices_json='${{ needs.call_get_app_metadata.outputs.compatible_devices }}'
+          else
+            # Convert space-separated string to JSON array
+            devices_string="${{ inputs.run_for_devices }}"
+            devices_json=$(echo "${devices_string}" | jq -R 'split(" ")')
+          fi
+
+          # Generate SDK environment variables from device names
+          sdks_json=$(echo "${devices_json}" | jq -c 'map("$" + (. | ascii_upcase) + "_SDK")')
+
+          echo "sdks_config=${sdks_json}" >> "$GITHUB_OUTPUT"
+
+      - name: Print devices and SDKs
+        run: |
+          echo "SDKs: ${{ steps.sdk_list.outputs.sdks_config }}"
+
+  analyse:
+    name: Analyse application
+    needs: build_device_matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: ${{ fromJSON(needs.build_device_matrix.outputs.sdks_config) }}
+        # 'cpp' covers C and C++
+        language: ['cpp']
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ledgerhq/ledger-app-builder/${{ inputs.builder }}:latest
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.app_repository }}
+          ref: ${{ inputs.app_branch_name }}
+          submodules: recursive
+          token: ${{ secrets.token && secrets.token || github.token }}
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      # CodeQL will create the database during the compilation
+      - name: Build
+        run: |
+          ${{ inputs.flags }} make BOLOS_SDK=${{ matrix.sdk }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/reusable_python_checks.yml
+++ b/.github/workflows/reusable_python_checks.yml
@@ -1,0 +1,99 @@
+name: Code style check
+
+on:
+  workflow_call:
+    inputs:
+      run_linter:
+        description: "Select the Linter to run (pylint or flake8)"
+        type: string
+        required: true
+        default: ''
+      run_type_check:
+        description: "Whether to run mypy type check (defaults to false)"
+        required: true
+        default: false
+        type: boolean
+      src_directory:
+        description: "The directory containing the python sources to check"
+        required: true
+        default: ''
+        type: string
+      req_directory:
+        description: "The directory containing the requirements.txt (if any)"
+        required: false
+        default: ''
+        type: string
+      setup_directory:
+        description: "The directory containing the setup.cfg (if any)"
+        required: false
+        default: ''
+        type: string
+      additional_packages:
+        description: "Additional packages to install (default to none)"
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  pylint:
+    name: Python Linting with pylint
+    if: ${{ inputs.run_linter == 'pylint' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Installing PIP dependencies
+        run: |
+          if [ -n "${{ inputs.additional_packages }}" ]; then
+            sudo apt-get update && sudo apt-get install -y ${{ inputs.additional_packages }}
+          fi
+          pip install pylint
+          if [ -n "${{ inputs.req_directory }}" ] && [ -f "${{ inputs.req_directory }}/requirements.txt" ]; then
+            pip install -r ${{ inputs.req_directory }}/requirements.txt
+          fi
+
+      - name: Lint Python code
+        run: |
+          ARGS=(-j 0)
+          if [ -n "${{ inputs.setup_directory }}" ] && [ -f "${{ inputs.setup_directory }}/setup.cfg" ]; then
+              ARGS+=(--rcfile "${{ inputs.setup_directory }}/setup.cfg")
+          fi
+          pylint "${ARGS[@]}" ${{ inputs.src_directory }}
+
+  flake8:
+    name: Python Linting with flake8
+    if: ${{ inputs.run_linter == 'flake8' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Installing PIP dependencies
+        run: |
+          pip install flake8 flake8-pyproject
+          if [ -n "${{ inputs.req_directory }}" ] && [ -f "${{ inputs.req_directory }}/requirements.txt" ]; then
+            pip install -r ${{ inputs.req_directory }}/requirements.txt
+          fi
+
+      - name: Lint Python code
+        run: |
+          cd ${{ inputs.setup_directory }} && flake8 ${{ inputs.src_directory }}
+
+  mypy:
+    name: Type checking
+    if: ${{ inputs.run_type_check == true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Installing PIP dependencies
+        run: |
+          pip install mypy
+          if [ -n "${{ inputs.req_directory }}" ] && [ -f "${{ inputs.req_directory }}/requirements.txt" ]; then
+            pip install -r ${{ inputs.req_directory }}/requirements.txt
+          fi
+
+      - name: Mypy type checking
+        run: mypy ${{ inputs.src_directory }}

--- a/.github/workflows/reusable_unit_tests.yml
+++ b/.github/workflows/reusable_unit_tests.yml
@@ -1,0 +1,79 @@
+name: Unit testing with Codecov coverage checking and upload the result
+
+on:
+  workflow_call:
+    inputs:
+      app_repository:
+        description: 'The GIT repository to test (defaults to `github.repository`)'
+        required: false
+        default: ${{ github.repository }}
+        type: string
+      app_branch_name:
+        description: 'The GIT branch to test (defaults to `github.ref`)'
+        required: false
+        default: ${{ github.ref }}
+        type: string
+      test_directory:
+        description: "The directory containing the unit-tests to run"
+        required: true
+        default: ''
+        type: string
+      builder:
+        description: "The docker image to build the application in (defaults to ledger-app-builder-lite)"
+        required: false
+        default: 'ledger-app-builder-lite'
+        type: string
+
+jobs:
+  unit_test:
+    name: Unit test
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ledgerhq/ledger-app-builder/${{ inputs.builder }}:latest
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.app_repository }}
+          ref: ${{ inputs.app_branch_name }}
+          submodules: recursive
+          token: ${{ secrets.token && secrets.token || github.token }}
+
+      - name: Build unit tests
+        run: |
+          cd ${{ inputs.test_directory }}
+          cmake -Bbuild -H. && make -C build
+
+      - name: Run unit tests
+        run: |
+          cd ${{ inputs.test_directory }}
+          make -C build test
+
+      - name: Generate code coverage
+        run: |
+          cd ${{ inputs.test_directory }}
+          lcov --directory . -b "$(realpath build/)" --capture --initial -o coverage.base
+          lcov --rc lcov_branch_coverage=1 --directory . -b "$(realpath build/)" --capture -o coverage.capture
+          lcov --directory . -b "$(realpath build/)" --add-tracefile coverage.base --add-tracefile coverage.capture -o coverage.info
+          lcov --directory . -b "$(realpath build/)" --remove coverage.info "*/${{ inputs.test_directory }}/*" -o coverage.info
+          genhtml coverage.info -o coverage
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage
+          path: ${{ inputs.test_directory }}/coverage
+
+      - name: Install codecov dependencies
+        run: apt install --no-install-recommends -y curl gpg
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.codecov_token }}
+        with:
+          files: ./${{ inputs.test_directory }}/coverage.info
+          flags: unittests
+          name: codecov-${{ inputs.app_repository }}
+          fail_ci_if_error: true
+          verbose: true


### PR DESCRIPTION
Add reusable workflows for

- unit tests, tested here:
  - https://github.com/LedgerHQ/app-boilerplate/actions/runs/17773993676
  - https://github.com/LedgerHQ/app-openpgp/actions/runs/17774858335
- codeql, tested here:
  - https://github.com/LedgerHQ/app-boilerplate/actions/runs/17774156145
  - https://github.com/LedgerHQ/app-exchange/actions/runs/17774487238
  - https://github.com/LedgerHQ/app-nbgl-tests/actions/runs/17774596377
  - https://github.com/LedgerHQ/app-openpgp/actions/runs/17774858398
- python checks, tested here:
  - https://github.com/LedgerHQ/app-boilerplate/actions/runs/17773993656
  - https://github.com/LedgerHQ/app-nbgl-tests/actions/runs/17774585010
  - https://github.com/LedgerHQ/app-openpgp/actions/runs/17774858366
  - https://github.com/LedgerHQ/app-openpgp/actions/runs/17774858377