### PR TITLE
Updating reusable build : source branch and target branch comparisons

### DIFF
--- a/.github/workflows/end_to_end_tests_of_reusable_workflows.yml
+++ b/.github/workflows/end_to_end_tests_of_reusable_workflows.yml
@@ -116,6 +116,7 @@ jobs:
       upload_app_binaries_artifact: libraries_binaries-${{ matrix.coin.name }}-${{ strategy.job-index }}
       upload_as_lib_artifact: ${{ matrix.coin.name }}
       builder: ledger-app-builder
+      build_comparison: false
 
   merge_libraries_build:
     name: Merge built libraries
@@ -136,6 +137,7 @@ jobs:
       app_branch_name: develop
       flags: "TESTING=1 TEST_PUBLIC_KEY=1"
       upload_app_binaries_artifact: exchange_binaries
+      build_comparison: false
 
   ragger_tests_exchange:
     name: Run Exchange tests
@@ -151,6 +153,7 @@ jobs:
       lib_binaries_artifact_dir: test/python/lib_binaries
       # No need to run everyone, we are testing the reusable workflows not exchange
       test_filter: "ethereum"
+      post_stack_consumption: false
 
   #####################################
   ######### Boilerplate tests #########
@@ -163,6 +166,7 @@ jobs:
       app_repository: LedgerHQ/app-boilerplate
       app_branch_name: master
       upload_app_binaries_artifact: "boilerplate_binaries"
+      build_comparison: false
 
   ragger_tests_boilerplate:
     name: Run boilerplate tests
@@ -173,6 +177,7 @@ jobs:
       app_branch_name: master
       download_app_binaries_artifact: "boilerplate_binaries"
       test_dir: "tests/standalone"
+      post_stack_consumption: false
 
   ragger_swap_tests_boilerplate:
     name: Run boilerplate swap tests
@@ -195,6 +200,8 @@ jobs:
       app_branch_name: develop
       upload_app_binaries_artifact: plugin_boilerplate_binaries
       flags: "DEBUG=1"
+      build_comparison: false
+
 
   build_develop_ethereum_app:
     name: Build Ethereum
@@ -204,6 +211,8 @@ jobs:
       app_branch_name: develop
       flags: "DEBUG=1 CAL_TEST_KEY=1"
       upload_app_binaries_artifact: ethereum_build_develop
+      build_comparison: false
+
 
   ragger_tests_plugin_boilerplate:
     name: Run plugin boilerplate tests
@@ -217,6 +226,7 @@ jobs:
       download_app_binaries_artifact: plugin_boilerplate_binaries
       additional_app_binaries_artifact: ethereum_build_develop
       additional_app_binaries_artifact_dir: ./tests/.test_dependencies/ethereum/build
+      post_stack_consumption: false
 
 
   ####################################
@@ -231,6 +241,7 @@ jobs:
       app_branch_name: main
       upload_app_binaries_artifact: "rust_boilerplate_binaries"
       builder: ledger-app-builder
+      build_comparison: false
 
   ragger_tests_rust_boilerplate:
     name: Run rust boilerplate tests
@@ -240,6 +251,7 @@ jobs:
       app_repository: LedgerHQ/app-boilerplate-rust
       app_branch_name: main
       download_app_binaries_artifact: "rust_boilerplate_binaries"
+      post_stack_consumption: false
 
   ####################################
   ######### Ragger deployment ########

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -67,10 +67,24 @@ on:
         required: false
         default: ""
         type: string
+      build_comparison:
+        description: "Whether to perform a build comparison between source and target branches (defaults to false).
+                      Requires upload_app_binaries_artifact to be set.
+                      If false, not target branch build will be performed, and no artifact will be uploaded for the target branch."
+        required: false
+        default: true
+        type: boolean
+      enable_stack_consumption:
+        description: "Whether to enable stack consumption tracking in the build (defaults to true).
+                      Sets DEBUG_OS_STACK_CONSUMPTION=1 for C apps and --features stack_usage for Rust apps."
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
-  actions: write  # Needed for upload-artifact
+  actions: write        # Needed for upload-artifact
+  pull-requests: write  # Needed to post PR comments
 
 env:
   APP_REPOSITORY: ${{ inputs.app_repository }}
@@ -107,7 +121,7 @@ jobs:
       fail-fast: false
       matrix:
         device: ${{ fromJSON(needs.call_get_app_metadata.outputs.compatible_devices) }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/ledgerhq/ledger-app-builder/${{ inputs.builder }}:latest
 
@@ -150,12 +164,20 @@ jobs:
               # Update the Rust SDK crate
               cargo +$RUST_NIGHTLY update ledger_device_sdk
               # Build application
-              cargo +$RUST_NIGHTLY ledger build "${BUILD_DEVICE_NAME}" -- ${CARGO_LEDGER_BUILD_ARGS}
+              RUST_FEATURES=""
+              if [ "${{ inputs.enable_stack_consumption }}" = "true" ]; then
+                RUST_FEATURES="--features ledger_device_sdk/stack_usage"
+              fi
+              cargo +$RUST_NIGHTLY ledger build "${BUILD_DEVICE_NAME}" -- ${RUST_FEATURES} ${CARGO_LEDGER_BUILD_ARGS}
               binary_path=$(cargo +$RUST_NIGHTLY metadata --no-deps --format-version 1 | jq -r '.target_directory')
               echo "binary_path=${binary_path}" >> "${GITHUB_OUTPUT}"
           else
               echo "Using BOLOS_SDK: ${BOLOS_SDK}"
-              make -j ${{ needs.call_get_app_metadata.outputs.flags }} ${ADDITIONAL_ARGS} BOLOS_SDK="${BOLOS_SDK}"
+              STACK_FLAG=""
+              if [ "${{ inputs.enable_stack_consumption }}" = "true" ]; then
+                STACK_FLAG="DEBUG_OS_STACK_CONSUMPTION=1"
+              fi
+              make -j ${{ needs.call_get_app_metadata.outputs.flags }} ${ADDITIONAL_ARGS} ${STACK_FLAG} BOLOS_SDK="${BOLOS_SDK}"
               echo "binary_path=${{ needs.call_get_app_metadata.outputs.build_directory }}/build" >> "${GITHUB_OUTPUT}"
           fi
           echo "binary_path=${binary_path}"
@@ -207,7 +229,7 @@ jobs:
   merge_artifacts:
     name: Merge build artifacts
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: ${{ inputs.upload_app_binaries_artifact != '' }}
     steps:
       - uses: actions/upload-artifact/merge@v4
@@ -215,3 +237,225 @@ jobs:
           name: ${{ inputs.upload_app_binaries_artifact }}
           pattern: ${{ inputs.upload_app_binaries_artifact }}-*
           delete-merged: true
+
+  # The following jobs are used in PRs, to compare builds between source and target branches.
+  build_target_branch:
+    name: Build application for all selected devices (target branch)
+    if: ${{ inputs.build_comparison && github.event_name == 'pull_request' && inputs.upload_app_binaries_artifact != '' }}
+    needs: call_get_app_metadata
+    strategy:
+      fail-fast: false
+      matrix:
+        device: ${{ fromJSON(needs.call_get_app_metadata.outputs.compatible_devices) }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ledgerhq/ledger-app-builder/${{ inputs.builder }}:latest
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.app_repository }}
+          ref: ${{ github.base_ref }}
+          submodules: recursive
+          token: ${{ secrets.token && secrets.token || github.token }}
+
+      - name: Set device-specific environment variables
+        if: ${{ needs.call_get_app_metadata.outputs.is_rust == 'false' }}
+        shell: bash
+        run: |
+          eval "BOLOS_SDK=\$$(echo ${{ matrix.device }} | tr '[:lower:]' '[:upper:]')_SDK"
+          echo "BOLOS_SDK=${BOLOS_SDK}" >> "${GITHUB_ENV}"
+          echo "BOLOS_SDK will be set to: ${BOLOS_SDK}"
+
+      - name: Checkout SDK
+        if: ${{ needs.call_get_app_metadata.outputs.is_rust == 'false' && inputs.sdk_reference != '' }}
+        working-directory: ${{ env.BOLOS_SDK }}
+        shell: bash
+        run: |
+          echo "Using BOLOS_SDK: ${BOLOS_SDK}"
+          echo "Checking out reference '${SDK_REFERENCE}'..."
+          git fetch -apt && git checkout ${SDK_REFERENCE}
+          DEVICE=${{ matrix.device }}
+          echo "ADDITIONAL_ARGS=TARGET=${DEVICE/sp/s2}" >> "${GITHUB_ENV}"
+
+      - name: Build application
+        id: "build"
+        working-directory: ${{ needs.call_get_app_metadata.outputs.build_directory }}
+        shell: bash
+        run: |
+          if [ "${{ needs.call_get_app_metadata.outputs.is_rust }}" = "true" ];
+          then
+              BUILD_DEVICE_NAME="$(echo "${{ matrix.device }}" | sed 's/nanosp/nanosplus/')"
+              cargo +$RUST_NIGHTLY update ledger_device_sdk
+              cargo +$RUST_NIGHTLY ledger build "${BUILD_DEVICE_NAME}" -- ${CARGO_LEDGER_BUILD_ARGS}
+              binary_path=$(cargo +$RUST_NIGHTLY metadata --no-deps --format-version 1 | jq -r '.target_directory')
+              echo "binary_path=${binary_path}" >> "${GITHUB_OUTPUT}"
+          else
+              echo "Using BOLOS_SDK: ${BOLOS_SDK}"
+              make -j ${{ needs.call_get_app_metadata.outputs.flags }} ${ADDITIONAL_ARGS} BOLOS_SDK="${BOLOS_SDK}"
+              echo "binary_path=${{ needs.call_get_app_metadata.outputs.build_directory }}/build" >> "${GITHUB_OUTPUT}"
+          fi
+          echo "binary_path=${binary_path}"
+          echo "Build complete"
+
+      - name: Remove build artifacts before upload
+        run: |
+          if [ "${{ needs.call_get_app_metadata.outputs.is_rust }}" = "true" ];
+          then
+              find ${{ steps.build.outputs.binary_path }} -mindepth 3 -maxdepth 3 -type d -exec rm -rf {} +
+              rm -rf ${{ steps.build.outputs.binary_path }}/release
+          else
+              find ${{ steps.build.outputs.binary_path }} -mindepth 2 -maxdepth 2 -type d ! -name 'bin' -exec rm -r {} +
+          fi
+
+      - name: Prepare to upload as lib
+        if: ${{ inputs.upload_as_lib_artifact != '' }}
+        shell: bash
+        run: |
+          if [ "${{ needs.call_get_app_metadata.outputs.is_rust }}" = "true" ];
+          then
+            C_DEVICE_NAME="$(echo "${{ matrix.device }}" | sed 's/nanosp/nanos2/')"
+            RUST_DEVICE_NAME="$(echo "${{ matrix.device }}" | sed 's/sp/splus/')"
+            ELF_NAME=$(cargo +$RUST_NIGHTLY metadata --manifest-path ${{ needs.call_get_app_metadata.outputs.build_directory }}/Cargo.toml --no-deps --format-version 1 | jq -r '.packages[] | select(.metadata.ledger != null) | .name')
+            mv "${{ steps.build.outputs.binary_path }}/${RUST_DEVICE_NAME}/release/${ELF_NAME}" "${{ steps.build.outputs.binary_path }}/${UPLOAD_AS_LIB_ARTIFACT}_${C_DEVICE_NAME}.elf"
+            rm -rf "${{ steps.build.outputs.binary_path }}/${RUST_DEVICE_NAME}"
+          else
+            DEVICE_NAME="$(echo "${{ matrix.device }}" | sed 's/nanosp/nanos2/')"
+            find "${{ needs.call_get_app_metadata.outputs.build_directory }}/build/${DEVICE_NAME}/" -type f -name 'app.elf' -exec mv {} "${UPLOAD_AS_LIB_ARTIFACT}_${DEVICE_NAME}.elf" \;
+            rm -r ${{ needs.call_get_app_metadata.outputs.build_directory }}/build/*
+            mv "${UPLOAD_AS_LIB_ARTIFACT}_${DEVICE_NAME}.elf" "${{ needs.call_get_app_metadata.outputs.build_directory }}/build/"
+          fi
+
+      - name: Display structure of binary files
+        run: |
+          ls -1 ${{ steps.build.outputs.binary_path }}
+
+      - name: Upload app binary
+        if: ${{ inputs.upload_app_binaries_artifact != '' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ inputs.upload_app_binaries_artifact }}_target-${{ matrix.device }}
+          path: ${{ steps.build.outputs.binary_path }}
+          if-no-files-found: error
+
+  merge_artifacts_target_branch:
+    name: Merge build artifacts (target branch)
+    needs: build_target_branch
+    runs-on: ubuntu-latest
+    if: ${{ inputs.build_comparison && github.event_name == 'pull_request' && inputs.upload_app_binaries_artifact != '' }}
+    steps:
+      - uses: actions/upload-artifact/merge@v4
+        with:
+          name: ${{ inputs.upload_app_binaries_artifact }}_target
+          pattern: ${{ inputs.upload_app_binaries_artifact }}_target-*
+          delete-merged: true
+
+  diff_elf_sizes:
+    name: Report ELF section sizes and post PR comment
+    needs: [call_get_app_metadata, merge_artifacts, merge_artifacts_target_branch]
+    runs-on: ubuntu-latest
+    if: ${{ inputs.build_comparison && github.event_name == 'pull_request' && inputs.upload_app_binaries_artifact != '' }}
+
+    steps:
+      - name: Install binutils
+        run: sudo apt-get install -y --no-install-recommends binutils
+
+      - name: Download source branch artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.upload_app_binaries_artifact }}
+          path: source_artifact/
+
+      - name: Download target branch artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.upload_app_binaries_artifact }}_target
+          path: target_artifact/
+
+      - name: Compute ELF section sizes
+        shell: bash
+        run: |
+          SRC="${GITHUB_HEAD_REF}"
+          TGT="${GITHUB_BASE_REF}"
+          echo "elf sizes" >> elf_diff.md
+
+          echo "source = source branch ${SRC}" >> elf_diff.md
+          echo "target = target branch ${TGT}" >> elf_diff.md
+
+          echo "| Device | .text source | .text target | .text delta | .bss source | .bss target | .bss delta | max stack size source | max stack size target | max stack size delta |" >> elf_diff.md
+          echo "|--------|---:|---:|---:|---:|---:|---:|---:|---:|---:|" >> elf_diff.md
+          for device in $(echo '${{ needs.call_get_app_metadata.outputs.compatible_devices }}' | jq -r '.[]'); do
+
+              if ${{ needs.call_get_app_metadata.outputs.is_rust == 'true' }}; then
+                DEVICE_NAME="$(echo "${device}" | sed 's/nanosp/nanosplus/')"
+                APP_PATH_SRC=$(find source_artifact/${DEVICE_NAME}/release -type f ! -name '*.*' | head -n 1)
+                APP_PATH_TARGET=$(find target_artifact/${DEVICE_NAME}/release -type f ! -name '*.*' | head -n 1)
+              else
+                DEVICE_NAME="$(echo "${device}" | sed 's/nanosp/nanos2/')"
+                APP_PATH_SRC=$(find source_artifact/${DEVICE_NAME}/bin -name '*.elf' | head -n 1)
+                APP_PATH_TARGET=$(find target_artifact/${DEVICE_NAME}/bin -name '*.elf' | head -n 1)
+              fi
+
+              read src_text <<< $(size ${APP_PATH_SRC} | tail -n 1 | awk '{print $1}')
+              read tgt_text <<< $(size ${APP_PATH_TARGET} | tail -n 1 | awk '{print $1}')
+
+              src_bss=$(nm ${APP_PATH_SRC} | grep -w '_bss' | awk '{print "0x"$1}')
+              src_ebss=$(nm ${APP_PATH_SRC} | grep -w '_ebss' | awk '{print "0x"$1}')
+              src_bss_size=$((src_ebss - src_bss))
+
+              tgt_bss=$(nm ${APP_PATH_TARGET} | grep -w '_bss' | awk '{print "0x"$1}')
+              tgt_ebss=$(nm ${APP_PATH_TARGET} | grep -w '_ebss' | awk '{print "0x"$1}')
+              tgt_bss_size=$((tgt_ebss - tgt_bss))
+
+              bss_delta=$((src_bss_size - tgt_bss_size))
+
+              if [[ "$DEVICE_NAME" == "nanox" ]]; then
+                src_stack_size=8192
+                tgt_stack_size=8192
+              else
+                src_stack=$(nm ${APP_PATH_SRC} | grep -w '_stack' | awk '{print "0x"$1}')
+                src_estack=$(nm ${APP_PATH_SRC} | grep -w '_estack' | awk '{print "0x"$1}')
+                src_stack_size=$((src_estack - src_stack))
+                tgt_stack=$(nm ${APP_PATH_TARGET} | grep -w '_stack' | awk '{print "0x"$1}')
+                tgt_estack=$(nm ${APP_PATH_TARGET} | grep -w '_estack' | awk '{print "0x"$1}')
+                tgt_stack_size=$((tgt_estack - tgt_stack))
+              fi
+
+              stack_delta=$((src_stack_size - tgt_stack_size))
+
+              echo "| ${DEVICE_NAME} | ${src_text} | ${tgt_text} | $((src_text - tgt_text)) | ${src_bss_size} | ${tgt_bss_size} | ${bss_delta} | ${src_stack_size} | ${tgt_stack_size} | ${stack_delta} |" >> elf_diff.md
+          done
+
+      - name: Post or update PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- elf-size-diff -->';
+            const body = marker + '\n' + fs.readFileSync('elf_diff.md', 'utf8');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              console.log(`Updated comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+              console.log('Created new comment');
+            }

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -68,7 +68,7 @@ on:
         default: ""
         type: string
       build_comparison:
-        description: "Whether to perform a build comparison between source and target branches (defaults to false).
+        description: "Whether to perform a build comparison between source and target branches (defaults to true).
                       Requires upload_app_binaries_artifact to be set.
                       If false, not target branch build will be performed, and no artifact will be uploaded for the target branch."
         required: false
@@ -362,13 +362,13 @@ jobs:
         run: sudo apt-get install -y --no-install-recommends binutils
 
       - name: Download source branch artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.upload_app_binaries_artifact }}
           path: source_artifact/
 
       - name: Download target branch artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.upload_app_binaries_artifact }}_target
           path: target_artifact/

--- a/.github/workflows/reusable_ragger_tests.yml
+++ b/.github/workflows/reusable_ragger_tests.yml
@@ -89,6 +89,20 @@ on:
         required: false
         default: ''
         type: string
+      post_stack_consumption:
+        description: "Whether to post a stack consumption summary comment on PRs (defaults to true).
+                     Requires `reusable_build.yml` to be configured with `enable_stack_consumption == true`.
+                     Requires the ELF size diff comment from reusable_build to exist."
+        required: false
+        default: true
+        type: boolean
+      stack_consumption_section_id:
+        description: "Unique identifier for the stack consumption comment section.
+                     Used to avoid collisions when multiple workflows post stack summaries on the same PR
+                     (e.g. ragger tests vs swap tests). Defaults to 'stack-consumption-summary'."
+        required: false
+        default: 'stack-consumption-summary'
+        type: string
     secrets:
       secret_test_options:
         description: 'A string of secret options to be given to `pytest`'
@@ -227,6 +241,10 @@ jobs:
           PYTEST_ARGS=("${{ needs.call_get_test_metadata.outputs.pytest_directory }}")
           PYTEST_ARGS+=(--tb=short -v --device "${{ matrix.device }}")
 
+          if [ "${{ inputs.post_stack_consumption }}" = "true" ]; then
+            PYTEST_ARGS+=(--get-stack-consumption)
+          fi
+
           if [ -n "${TEST_FILTER}" ] && [ "${TEST_FILTER}" != '""' ]; then
             # Remove leading and trailing quotes from the filter if they exist
             TRIMMED_FILTER="${TEST_FILTER%\"}"
@@ -252,8 +270,46 @@ jobs:
             # Capture pytest output to a file
             pytest "${PYTEST_ARGS[@]}" -s 2>&1 | tee pytest_output.log
           else
-            pytest "${PYTEST_ARGS[@]}"
+            pytest "${PYTEST_ARGS[@]}" 2>&1 | tee pytest_run.log
           fi
+
+      - name: Extract stack consumption summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          LOG_FILE="pytest_output.log"
+          if [ ! -f "$LOG_FILE" ]; then
+            LOG_FILE="pytest_run.log"
+          fi
+          if [ ! -f "$LOG_FILE" ]; then
+            echo "No pytest log found, skipping."
+            exit 0
+          fi
+          # Extract from "stack consumption summary" to the "worst case" separator
+          awk '/stack consumption summary/{found=1} found{print} /worst case:/{exit}' "$LOG_FILE" > stack_summary_${{ matrix.device }}.txt
+          if [ ! -s stack_summary_${{ matrix.device }}.txt ]; then
+            echo "No stack consumption data found for ${{ matrix.device }}."
+            rm -f stack_summary_${{ matrix.device }}.txt
+          else
+            cat stack_summary_${{ matrix.device }}.txt
+            echo "| Test | Stack |" >> ${GITHUB_STEP_SUMMARY}
+            echo "|------|--------------:|" >> ${GITHUB_STEP_SUMMARY}
+
+            # print stack summary detail, worst case line printed out separately
+            tail -n +2 stack_summary_${{ matrix.device }}.txt | head -n -1 |
+              sed -r -e 's/^/| /' -e 's/$/ |/' -e 's/([[:digit:]]+ bytes)\s+(\S+)/\2 | \1 |/' >> ${GITHUB_STEP_SUMMARY}
+
+            # print worst case line
+            echo "" >> ${GITHUB_STEP_SUMMARY}
+            tail -n1 stack_summary_${{ matrix.device }}.txt >> ${GITHUB_STEP_SUMMARY}
+          fi
+
+      - name: Upload stack consumption summary
+        if: ${{ always() && hashFiles(format('stack_summary_{0}.txt', matrix.device)) != '' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ inputs.stack_consumption_section_id }}-${{ matrix.device }}
+          path: stack_summary_${{ matrix.device }}.txt
 
       - name: Upload pytest logs
         if: ${{ inputs.capture_file != '' }}
@@ -363,3 +419,139 @@ jobs:
       app_branch_name: ${{ inputs.app_branch_name }}
       snapshots_artifact_name: ${{ needs.merge_artifacts_if_needed.outputs.snapshot_artifact_name }}
       snapshots_directory: ${{ needs.call_get_test_metadata.outputs.pytest_directory }}/snapshots
+
+  post_stack_consumption:
+    name: Post stack consumption summary on PR
+    needs: [ragger_tests, call_get_app_metadata]
+    if: ${{ always() && inputs.post_stack_consumption && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Download all stack summary artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: ${{ inputs.stack_consumption_section_id }}-*
+          path: summaries
+          merge-multiple: true
+
+      - name: Download app binaries for stack reference
+        uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.additional_app_binaries_artifact != '' && inputs.additional_app_binaries_artifact || inputs.download_app_binaries_artifact }}
+          path: app_binaries/
+
+      - name: Install dependencies for comment generation
+        run: sudo apt-get install -y --no-install-recommends binutils
+
+      - name: Build PR comment body
+        id: build_comment
+        shell: bash
+        run: |
+          files=$(find summaries -name "stack_summary_*.txt" | sort)
+          if [ -z "$files" ]; then
+              echo "No stack summary files found."
+              echo "has_report=false" >> "$GITHUB_OUTPUT"
+              exit 0
+          fi
+
+          echo "| Device | Worst case (bytes) | Remaining stack (bytes) | Test |" > stack_comment.md
+          echo "|--------|------------------:|------------------:|------|" >> stack_comment.md
+
+          has_data=false
+          for f in $files; do
+              device=$(echo "$f" | sed -n 's/.*stack_summary_\(.*\)\.txt/\1/p')
+
+              if [ -n "${{ inputs.additional_app_binaries_artifact }}" ]; then
+                # additional_app_binaries_artifact is set (e.g. app-exchange for swap tests).
+                # It is always a C SDK app, so use the C layout.
+                DEVICE_NAME="$(echo "${device}" | sed 's/nanosp/nanos2/')"
+                APP_PATH=$(find app_binaries/${DEVICE_NAME}/bin -name '*.elf' | head -n 1)
+              elif ${{ needs.call_get_app_metadata.outputs.is_rust == 'true' }}; then
+                DEVICE_NAME="$(echo "${device}" | sed 's/nanosp/nanosplus/')"
+                APP_PATH=$(find app_binaries/${DEVICE_NAME}/release -type f ! -name '*.*' | head -n 1)
+              else
+                DEVICE_NAME="$(echo "${device}" | sed 's/nanosp/nanos2/')"
+                APP_PATH=$(find app_binaries/${DEVICE_NAME}/bin -name '*.elf' | head -n 1)
+              fi
+
+              # hardcoded limit of 8kp for nanox
+              if [[ "$DEVICE_NAME" == "nanox" ]]; then
+                max_stack_size=8192
+              else
+                estack_addr=$(nm ${APP_PATH} | grep -w '_estack' | awk '{print "0x"$1}')
+                stack_addr=$(nm ${APP_PATH} | grep -w '_stack' | awk '{print "0x"$1}')
+                max_stack_size=$((estack_addr - stack_addr))
+              fi
+
+              [ -z "$device" ] && device="unknown"
+              while IFS= read -r line; do
+                  if echo "$line" | grep -iqE 'worst case:\s*[0-9]+\s+bytes'; then
+                      bytes=$(echo "$line" | sed -n 's/.*worst case:\s*\([0-9]\+\)\s\+bytes.*/\1/Ip')
+                      test_name=$(echo "$line" | sed -n 's/.*worst case:\s*[0-9]\+\s\+bytes\s*(\(.*\))/\1/Ip' | sed 's/[[:space:]]*-*$//')
+                      echo "| ${device} | ${bytes} | $((max_stack_size - bytes)) | \`${test_name}\` |" >> stack_comment.md
+                      has_data=true
+                      break
+                  fi
+              done < "$f"
+          done
+
+          if [ "$has_data" = false ]; then
+              echo "has_report=false" >> "$GITHUB_OUTPUT"
+              exit 0
+          fi
+
+          echo "has_report=true" >> "$GITHUB_OUTPUT"
+
+      - name: Post or update PR comment
+        if: ${{ steps.build_comment.outputs.has_report == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const elfMarker   = '<!-- elf-size-diff -->';
+            const stackMarker = '<!-- ${{ inputs.stack_consumption_section_id }} -->';
+            const disclaimer =
+              '> :warning: This summary is for informative purpose only. ' +
+              'It may not give the application actual worst case, for example if the test coverage is low.';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sectionId = '${{ inputs.stack_consumption_section_id }}';
+            const sectionTitle = sectionId === 'stack-consumption-summary'
+              ? 'Stack consumption summary'
+              : 'Stack consumption summary (' + sectionId.replace('stack-consumption-summary-', '') + ')';
+            const stackSection =
+              stackMarker + '\n ' + sectionTitle + '\n\n' +
+              disclaimer + '\n\n' +
+              fs.readFileSync('stack_comment.md', 'utf8') +
+              `\n[Full details](${runUrl})`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            // Prefer appending to / updating inside the ELF diff comment
+            const elfComment = comments.find(c => c.body && c.body.includes(elfMarker));
+            if (!elfComment) {
+              core.setFailed(
+                'No ELF size diff comment found on this PR. ' +
+                'The reusable_build workflow with build_comparison enabled must run first to create the comment.'
+              );
+              return;
+            }
+
+            // Replace existing stack section, or append it.
+            // The regex matches from this marker up to the next HTML comment marker or end of string,
+            // so that other stack sections (e.g. swap vs ragger) are preserved.
+            const newBody = elfComment.body.includes(stackMarker)
+              ? elfComment.body.replace(
+                  new RegExp(stackMarker + '[\\s\\S]*?(?=\\n\\n<!--|$)'),
+                  stackSection)
+              : elfComment.body.trimEnd() + '\n\n' + stackSection;
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: elfComment.id,
+              body: newBody,
+            });
+            console.log(`Appended stack section to ELF comment ${elfComment.id}`);

--- a/.github/workflows/reusable_ragger_tests.yml
+++ b/.github/workflows/reusable_ragger_tests.yml
@@ -129,6 +129,7 @@ env:
   REGENERATE_SNAPSHOTS: ${{ inputs.regenerate_snapshots }}
   CONTAINER_IMAGE: ${{ inputs.container_image }}
   CAPTURE_FILE: ${{ inputs.capture_file }}
+  POST_STACK_CONSUMPTION: ${{ inputs.post_stack_consumption }}
 
 jobs:
   call_get_app_metadata:
@@ -157,7 +158,7 @@ jobs:
       fail-fast: false
       matrix:
         device: ${{ fromJSON(needs.call_get_app_metadata.outputs.compatible_devices) }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: ${{ inputs.container_image != '' && inputs.container_image || null }}
 
     steps:
@@ -241,7 +242,7 @@ jobs:
           PYTEST_ARGS=("${{ needs.call_get_test_metadata.outputs.pytest_directory }}")
           PYTEST_ARGS+=(--tb=short -v --device "${{ matrix.device }}")
 
-          if [ "${{ inputs.post_stack_consumption }}" = "true" ]; then
+          if [ "${POST_STACK_CONSUMPTION}" = "true" ]; then
             PYTEST_ARGS+=(--get-stack-consumption)
           fi
 
@@ -371,7 +372,7 @@ jobs:
   merge_pytest_logs:
     name: Merge pytest logs
     needs: ragger_tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: ${{ inputs.capture_file != '' }}
     steps:
       - uses: actions/download-artifact@v7
@@ -394,7 +395,7 @@ jobs:
     # Merge matrix output
     name: Merge snapshots artifacts
     needs: ragger_tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/upload-artifact/merge@v4
         if: ${{ needs.ragger_tests.outputs.snapshot_artifact_uploaded == 'true' }}
@@ -424,7 +425,7 @@ jobs:
     name: Post stack consumption summary on PR
     needs: [ragger_tests, call_get_app_metadata]
     if: ${{ always() && inputs.post_stack_consumption && github.event_name == 'pull_request' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Download all stack summary artifacts

--- a/.github/workflows/reusable_swap_tests.yml
+++ b/.github/workflows/reusable_swap_tests.yml
@@ -111,6 +111,7 @@ jobs:
       upload_app_binaries_artifact: ${{ needs.compute_artifact_names.outputs.app_binaries_artifact }}
       use_case: ${{ inputs.use_case }}
       builder: ledger-app-builder
+      build_comparison: false
 
   build_exchange:
     name: Build Exchange app using the reusable workflow
@@ -122,6 +123,7 @@ jobs:
       app_branch_name: 'develop'
       upload_app_binaries_artifact: ${{ needs.compute_artifact_names.outputs.exchange_binaries_artifact }}
       use_case: 'use_test_keys'
+      build_comparison: false
 
   build_ethereum:
     name: Build Ethereum app using the reusable workflow
@@ -133,6 +135,7 @@ jobs:
       app_branch_name: 'develop'
       upload_app_binaries_artifact: ${{ needs.compute_artifact_names.outputs.ethereum_binaries_artifact }}
       use_case: 'use_test_keys'
+      build_comparison: false
 
   get_swap_test_metadata:
     name: Retrieve swap test metadata
@@ -200,3 +203,5 @@ jobs:
       lib_binaries_artifact_dir: ${{ needs.get_swap_test_metadata.outputs.lib_app_dir }}
       test_dir: ${{ needs.get_swap_test_metadata.outputs.swap_test_dir }}
       regenerate_snapshots: ${{ inputs.regenerate_snapshots }}
+      post_stack_consumption: false  # XXX : for now this feature is not compatible with swap tests. Will be fixed in upcoming PR.
+      stack_consumption_section_id: 'stack-consumption-summary-swap'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.95.0] - 2026-04-15
+
+### Added
+
+- `reusable_build.yml` : added option `build_comparison` for elf sections comment in prs.
+- `reusable_build.yml` : added option `enable_stack_consumption` so `reusable_ragger_tests.yml` can use `--get-stack-consumption` for stack consumption comment in prs.
+- `reusable_ragger_tests.yml` : added option `post_stack_consumption` for stack consumption comment in prs. requires `enable_stack_consumption == true` in `reusable_build.yml`.
+
 ## [1.94.27] - 2026-04-27
 
 ### Changed

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,6 +29,8 @@ In order to build an App, this workflow can use the following input parameters:
 | builder                      | ❌       | `ledger-app-builder-lite` | The docker image to build the application in |
 | sdk_reference                | ❌       |                           | A SDK reference to checkout before building the app |
 | cargo_ledger_build_args      | ❌       |                           | Additional arguments to pass to the cargo |
+| build_comparison             | ❌       | `true`                    | Whether to build the target branch and report ELF size diffs on PRs |
+| enable_stack_consumption     | ❌       | `true`                    | Enable stack consumption tracking (`DEBUG_OS_STACK_CONSUMPTION=1` for C, `--features stack_usage` for Rust) |
 
 In addition, the following secret can be used:
 
@@ -76,6 +78,7 @@ In order to test an App, this workflow can use the following input parameters:
 | test_options                         | ❌       |                           | Specify optional parameters to be passed to the running test |
 | container_image                      | ❌       |                           | Optional container image to run the ragger_tests job |
 | capture_file                         | ❌       |                           | Optional file name to capture pytest logs into an artifact |
+| post_stack_consumption               | ❌       | `true`                    | Post a stack consumption summary on PRs. Requires `reusable_build` with `enable_stack_consumption` and `build_comparison` enabled |
 
 In addition, the following secret can be used:
 


### PR DESCRIPTION
- [x] comparing binary sizes between source and target branches (`reusable_build.yml`)
- [x] comparing stack usage between source and target branches (`reusable_ragger_tests.yml`)
- [ ] comparing swap tests stack usage between source and target branches.

:warning: for now swap tests will be ignored, it works fine for nanos+ and nanox, but not on stax, flex and apex. This will be fixed in a dedicated PR.