### PR TITLE
disable build_comparison by default

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -72,13 +72,13 @@ on:
                       Requires upload_app_binaries_artifact to be set.
                       If false, not target branch build will be performed, and no artifact will be uploaded for the target branch."
         required: false
-        default: true
+        default: false
         type: boolean
       enable_stack_consumption:
         description: "Whether to enable stack consumption tracking in the build (defaults to true).
                       Sets DEBUG_OS_STACK_CONSUMPTION=1 for C apps and --features stack_usage for Rust apps."
         required: false
-        default: true
+        default: false
         type: boolean
 
 permissions:

--- a/.github/workflows/reusable_ragger_tests.yml
+++ b/.github/workflows/reusable_ragger_tests.yml
@@ -94,7 +94,7 @@ on:
                      Requires `reusable_build.yml` to be configured with `enable_stack_consumption == true`.
                      Requires the ELF size diff comment from reusable_build to exist."
         required: false
-        default: true
+        default: false
         type: boolean
       stack_consumption_section_id:
         description: "Unique identifier for the stack consumption comment section.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.95.4] - 2026-05-04
+
+### Changed
+
+- `reusable_build.yml` : `build_comparison` and `enable_stack_consumption` are now disable by default.
+- `reusable_ragger_tests.yml` : `post_stack_consumption` is now disabled by default.
+
 ## [1.95.3] - 2026-04-30
 
 ### Changed

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,8 +29,8 @@ In order to build an App, this workflow can use the following input parameters:
 | builder                      | ❌       | `ledger-app-builder-lite` | The docker image to build the application in |
 | sdk_reference                | ❌       |                           | A SDK reference to checkout before building the app |
 | cargo_ledger_build_args      | ❌       |                           | Additional arguments to pass to the cargo |
-| build_comparison             | ❌       | `true`                    | Whether to build the target branch and report ELF size diffs on PRs |
-| enable_stack_consumption     | ❌       | `true`                    | Enable stack consumption tracking (`DEBUG_OS_STACK_CONSUMPTION=1` for C, `--features stack_usage` for Rust) |
+| build_comparison             | ❌       | `false`                   | Whether to build the target branch and report ELF size diffs on PRs |
+| enable_stack_consumption     | ❌       | `false`                   | Enable stack consumption tracking (`DEBUG_OS_STACK_CONSUMPTION=1` for C, `--features stack_usage` for Rust) |
 
 In addition, the following secret can be used:
 
@@ -78,7 +78,7 @@ In order to test an App, this workflow can use the following input parameters:
 | test_options                         | ❌       |                           | Specify optional parameters to be passed to the running test |
 | container_image                      | ❌       |                           | Optional container image to run the ragger_tests job |
 | capture_file                         | ❌       |                           | Optional file name to capture pytest logs into an artifact |
-| post_stack_consumption               | ❌       | `true`                    | Post a stack consumption summary on PRs. Requires `reusable_build` with `enable_stack_consumption` and `build_comparison` enabled |
+| post_stack_consumption               | ❌       | `false`                   | Post a stack consumption summary on PRs. Requires `reusable_build` with `enable_stack_consumption` and `build_comparison` enabled |
 
 In addition, the following secret can be used:
 


### PR DESCRIPTION
reusable_build build_comparison and enable_stack_consumption are disabled by default. reusable_ragger_test post_stack_consumption is disabled by default.
