### PR TITLE
Fix unit test

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -439,7 +439,7 @@ jobs:
           done
 
       - name: Post or update PR comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         continue-on-error: true
         with:
           script: |

--- a/.github/workflows/reusable_ragger_tests.yml
+++ b/.github/workflows/reusable_ragger_tests.yml
@@ -517,7 +517,7 @@ jobs:
 
       - name: Post or update PR comment
         if: ${{ steps.build_comment.outputs.has_report == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         continue-on-error: true
         with:
           script: |

--- a/.github/workflows/reusable_unit_tests.yml
+++ b/.github/workflows/reusable_unit_tests.yml
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/upload-artifact@v6
         with:
           name: code-coverage
-          path: ${{ inputs.test_directory }}/coverage
+          path: ${{ env.WORK_DIR }}/coverage
 
       - name: Install codecov dependencies
         run: |
@@ -113,7 +113,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.codecov_token }}
         with:
-          files: ./${{ inputs.test_directory }}/coverage.info
+          files: ${{ env.WORK_DIR }}/coverage.info
           flags: unittests
           name: codecov-${{ inputs.app_repository }}
           fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.95.9] - 2026-05-25
+
+### Fixed
+
+- `reusable_unit_tests.yml` : Fix working directory for coverage upload
+
 ## [1.95.8] - 2026-05-12
 
 ### Removed


### PR DESCRIPTION

`reusable_unit_tests.yml` : coverage upload and Codecov paths used the deprecated `inputs.test_directory` (empty by default) instead of the value resolved via `ledger-manifest`. Now use `${{ env.WORK_DIR }}`, which has a proper fallback when no sub-directory is set.

Bonus: Update Action version for `actions/github-script`