### PR TITLE
fix(unit_tests): unblock lcov capture under gcov 14

### DIFF
--- a/.github/workflows/reusable_unit_tests.yml
+++ b/.github/workflows/reusable_unit_tests.yml
@@ -93,11 +93,20 @@ jobs:
       - name: Generate code coverage
         working-directory: ${{ env.WORK_DIR }}
         run: |
-          lcov --directory . -b "$(realpath build/)" --capture --initial -o coverage.base
-          lcov --rc lcov_branch_coverage=1 --directory . -b "$(realpath build/)" --capture -o coverage.capture
-          lcov --directory . -b "$(realpath build/)" --add-tracefile coverage.base --add-tracefile coverage.capture -o coverage.info
-          lcov --directory . -b "$(realpath build/)" --remove coverage.info "*/${TEST_DIRECTORY}/*" -o coverage.info
-          genhtml coverage.info -o coverage
+          # --ignore-errors negative: gcov 14 occasionally emits negative
+          # branch-taken counts in instrumented .gcda files (upstream gcov
+          # regression). lcov 2.x rejects them as a fatal error and breaks
+          # the coverage step even though every test passed. Suppress only
+          # on the capture commands -- merge/remove operate on the already
+          # captured .info files so they can't hit this path.
+          # --branch-coverage replaces the deprecated --rc lcov_branch_coverage=1
+          # and is honoured by lcov 2.x on every subcommand (capture, merge,
+          # remove, genhtml) so the branch data survives the whole pipeline.
+          lcov --branch-coverage --ignore-errors negative --directory . -b "$(realpath build/)" --capture --initial -o coverage.base
+          lcov --branch-coverage --ignore-errors negative --directory . -b "$(realpath build/)" --capture -o coverage.capture
+          lcov --branch-coverage --directory . -b "$(realpath build/)" --add-tracefile coverage.base --add-tracefile coverage.capture -o coverage.info
+          lcov --branch-coverage --directory . -b "$(realpath build/)" --remove coverage.info "*/${TEST_DIRECTORY}/*" -o coverage.info
+          genhtml --branch-coverage coverage.info -o coverage
 
       - uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/reusable_unit_tests.yml
+++ b/.github/workflows/reusable_unit_tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Installing required packages
         if: ${{ inputs.additional_packages != '' }}
         run: |
-          apt install --no-install-recommends -y ${ADDITIONAL_PACKAGES}
+          apt-get -q update && apt-get -q install --no-install-recommends -y ${ADDITIONAL_PACKAGES}
 
       - name: Clone
         uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.95.12] - 2026-06-02
+
+### Fixed
+
+- `reusable_unit_tests.yml` : Unblock `lcov` coverage capture under gcov 14. Added `--ignore-errors negative` on the `--capture` commands (gcov 14 occasionally emits negative branch-taken counts that lcov 2.x rejects as fatal) and replaced the deprecated `--rc lcov_branch_coverage=1` with `--branch-coverage` on all subcommands.
+
 ## [1.95.11] - 2026-05-26
 
 ### Fixed


### PR DESCRIPTION

gcov 14 occasionally emits negative branch-taken counts in instrumented .gcda files (an upstream regression vs gcov 13). lcov 2.x treats those as a fatal error and aborts the coverage step even when every unit test passes. Result: any app on the latest ledger-app-builder-lite (which ships gcov 14.2) sees its CI break at the "Generate code coverage" step.

Two small changes:

  1. Add --ignore-errors negative to both lcov --capture invocations (initial and non-initial). Scoped to capture only -- merge and remove operate on already-captured .info files and never hit the negative-count path, so they don't need the flag.

  2. Replace the deprecated --rc lcov_branch_coverage=1 (lcov 2.x flags it deprecated and prints a warning per invocation) with --branch-coverage, and apply it to every subcommand in the pipeline (capture, merge, remove, genhtml). Before this change the flag was only on the second capture, which meant the merge / remove / genhtml steps dropped any branch data they encountered.

Apps that previously worked around this with a per-repo tests/unit/.lcovrc can drop that file once they bump to the next v1 tag.