### PR TITLE
Add optional enable_codecov input to reusable_unit_tests

### DIFF
--- a/.github/workflows/reusable_unit_tests.yml
+++ b/.github/workflows/reusable_unit_tests.yml
@@ -40,6 +40,11 @@ on:
         required: false
         default: ''
         type: string
+      enable_codecov:
+        description: "Whether to upload the coverage result to Codecov (disable for repositories that cannot use Codecov, e.g. internal ones). The upload is also skipped when no codecov_token is provided."
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -52,6 +57,7 @@ env:
   BUILDER: ${{ inputs.builder }}
   ADDITIONAL_PACKAGES: ${{ inputs.additional_packages }}
   COVERAGE_EXCLUDE_PATHS: ${{ inputs.coverage_exclude_paths }}
+  CODECOV_TOKEN: ${{ secrets.codecov_token }}
 
 jobs:
   # Resolve the ref this reusable workflow was called with, so the steps below
@@ -149,7 +155,10 @@ jobs:
             ${{ env.WORK_DIR }}/coverage
             ${{ env.WORK_DIR }}/coverage.xml
 
+      # Skipped when disabled via `enable_codecov` (e.g. internal repositories
+      # that cannot use Codecov) or when no `codecov_token` is provided.
       - name: Upload to codecov.io
+        if: ${{ inputs.enable_codecov && env.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.codecov_token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.95.17] - 2026-06-10
+
+### Added
+
+- `reusable_unit_tests.yml` : New `enable_codecov` input (default `true`) to make the Codecov upload optional. The upload is also automatically skipped when no `codecov_token` is provided.
+
 ## [1.95.16] - 2026-06-08
 
 ### Fixed

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -206,6 +206,7 @@ In order to test an App, this workflow can use the following input parameters:
 | builder                | ❌       | `ledger-app-builder-lite` | The docker image to build the application in                                                                                      |
 | additional_packages    | ❌       |                           | Additional packages to install                                                                                                    |
 | coverage_exclude_paths | ❌       |                           | Space-separated glob patterns to exclude from the coverage result (`/usr/*`, `/opt/*` and the test directory are always excluded) |
+| enable_codecov         | ❌       | `true`                    | Whether to upload coverage to Codecov; `false` for repos that can't use it, e.g. internal (also skipped without `codecov_token`)  |
 
 In addition, the following secrets can be used:
 


### PR DESCRIPTION
The Codecov upload step uses `fail_ci_if_error: true`, which makes the unit-test job fail on repositories that cannot use Codecov (e.g. internal ones). Make the upload opt-out:

- New `enable_codecov` input (boolean, default `true`).
- The upload step is now gated on `enable_codecov && codecov_token != ''`, so it is also skipped automatically when no token is provided.
- `codecov_token` is mapped to a job-level `CODECOV_TOKEN` env var because the `secrets` context is not available in step-level `if` conditions.
